### PR TITLE
docs: make the README findable for the errors people actually search

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,18 @@ that installing it saves memory, but that what it points at is the real cause.
 Across ~25 healthy routes on production applications (PPR, MDX, Auth.js,
 Sentry, i18n), it reported **zero false positives**.
 
-Your server's memory climbs and the container gets OOM-killed. Almost every report of this ends the same way: *"please provide heap snapshots taken after forced GC"* — which almost nobody produces correctly. `next-leak` runs that controlled measurement for you and answers with evidence a maintainer would accept.
+Your self-hosted Next.js server's memory climbs until Node gives up:
+
+```
+FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
+```
+
+Under Docker or Kubernetes you may not even get that: the process is `OOMKilled`,
+the container exits with **code 137**, and the restart wipes the evidence before
+you can look at it. Almost every report of this ends the same way — *"please
+provide heap snapshots taken after forced GC"* — which almost nobody produces
+correctly. `next-leak` runs that controlled measurement for you and answers with
+evidence a maintainer would accept.
 
 Three possible answers, all valuable:
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,18 @@
   "description": "Find out whether your Next.js app actually leaks memory — how much, on which route, and whose fault it is.",
   "keywords": [
     "nextjs",
+    "next.js",
     "memory-leak",
+    "memory",
+    "oom",
+    "oomkilled",
+    "heap",
     "heap-snapshot",
+    "profiling",
+    "performance",
+    "nodejs",
     "diagnostics",
+    "debugging",
     "cli"
   ],
   "license": "MIT",


### PR DESCRIPTION
The README described the symptom in prose ("the container gets OOM-killed") but
contained none of the literal strings a developer pastes into a search box — or
into an LLM prompt — when their server dies.

Counted before the change:

```
OOMKilled            0
heap out of memory   0
Reached heap limit   0
exit code 137        0
Kubernetes           0
```

The blog post that drives traffic here already opens with those exact strings.
The README — which is what GitHub indexes, what npm renders, and what LLMs
ingest — had none of them.

- `docs(readme)`: name the real failure modes (`FATAL ERROR: Reached heap
  limit`, `OOMKilled`, exit code 137) inside the paragraph that already
  explained the symptom. Not keyword stuffing — it reads as the same
  description, with the errors quoted instead of paraphrased.
- `chore(npm)`: widen keywords from 5 to 14 so registry search has something
  to match.

No behaviour change. No source file touched.
