### PR TITLE
docs(security): document the bundle and puppeteer stub for supply-chain review

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,5 +8,36 @@ user data present in the process at capture time). Treat `.next-leak/`
 output directories as sensitive and do not attach raw snapshots to public
 issues — `run.json` is enough.
 
+## Supply chain
+
+What an installed copy of next-leak can and cannot do is deliberately
+narrow, and most of it is verifiable from the outside:
+
+- **Two runtime dependencies** (`semver`, `zod`). Everything else ships
+  pre-bundled in `dist/` — see below for why.
+- **The bundle exists to keep Chrome off your machine.** next-leak uses
+  memlab's heap-snapshot parser. Installing the memlab family normally
+  drags in puppeteer and xvfb — a full headless-browser download this tool
+  never uses. Instead, the parser is bundled at build time and `puppeteer`,
+  `puppeteer-core` and `xvfb` are aliased to a stub
+  (`src/stubs/browser-stub.cjs`) that throws loudly if anything ever
+  reaches it: the published package cannot launch or download a browser,
+  by construction.
+- **autocannon is bundled for a different reason**: its transitive tree
+  carries a uuid advisory with no upstream fix. Our build patches it via a
+  pnpm override, and overrides do not propagate to consumers — bundling
+  ships the patched tree.
+- **Security scanners will flag this package, and the flags are expected**:
+  it takes heap snapshots, forces GC through V8 debug APIs, injects
+  instrumentation into the measured app via `--import`, and spawns child
+  processes. That is the product's function, not a payload. The embedded
+  URLs scanners find are `127.0.0.1` control endpoints and github.com
+  links in generated issue drafts.
+- **Verify instead of trusting**: `dist/` is reproducible from source with
+  `pnpm build`, and `pnpm pack:smoke` installs the real tarball in
+  isolation and measures a fixture app — the gate every release must pass.
+
+## Reporting
+
 To report a vulnerability, email xabier.lameiro@gmail.com. You will get a
 response within 72 hours.


### PR DESCRIPTION
## What

Adds a **Supply chain** section to `SECURITY.md` covering what an installed
copy can and cannot do: the two runtime dependencies, why `dist/` ships
pre-bundled, what the puppeteer stub is, which scanner alerts are expected
and why, and how to verify all of it from source.

## Why

Socket's analysis of `next-leak@0.1.2` scores supply chain 81/100 with three
alerts: an AI-flagged "potential security risk", "debug access", and "URL
strings". All three are explainable and none is a defect:

- The AI flag is almost certainly the bundle — memlab embedded plus a module
  that impersonates `puppeteer`. That shape is exactly what an anomaly
  detector should flag; it exists so installs never download Chrome.
- "Debug access" is the product: forced GC, heap snapshots via V8, `--import`
  instrumentation, child processes. This alert will never go away, and
  shouldn't.
- "URL strings" are the `127.0.0.1` control endpoints and the github.com
  links inside generated issue drafts.

A tool that asks people to run it against their production app should explain
its own supply chain rather than leave a scanner to characterise it. This also
gives a reviewer something concrete to read when assessing the AI alert.

No source, build or published-artifact changes.

## Checklist

- [x] Tests cover the new behavior — n/a, docs only; no source touched
- [x] `pnpm typecheck && pnpm test` pass locally — n/a, no code in the diff (CI runs them anyway)
- [x] Verdict semantics untouched