### PR TITLE
feat!: scale the leak threshold with load and make the measurement regime explicit

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,8 @@
   "packages": {
     ".": {
       "release-type": "node",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
## What

Two things, both about the release of #20 rather than its code:

1. **Records the change from #20 as a conventional commit**, so release-please can see it.
2. **Sets `bump-minor-pre-major`**, so it lands as `0.2.0` instead of `1.0.0`.

The code from #20 is already on `main` and is not touched here. The only file changed is `release-please-config.json` (+1 line).

## Why

#20 was squash-merged with the subject `Make the verdict reproducible, and back the public claims with gates (#20)` — prose, not a conventional commit. Under squash-merge the PR title *is* the commit message that reaches `main`, so the four conventional commits on the branch survived only as bullets in the body, where release-please does not look.

The result: since `v0.1.3` there are **zero releasable commits** on `main`. The other five are `chore(deps)` bumps, which release-please ignores by design. The Release workflow ran after the merge (run `30160090303`) and succeeded — it simply found nothing to release. No release PR was opened, the manifest still reads `0.1.3`, and the largest behavioural change in the repo is live on `main` but unversioned, unpublished, and missing from the changelog. Anyone running `npx next-leak` today still gets 0.1.3 with the old verdict semantics.

The title of this PR is the conventional commit that #20 should have carried. Its body carries the `BREAKING CHANGE:` footer so the changelog gets a proper entry rather than a bare version bump.

### On the version

`bump-minor-pre-major` is documented in the release-please schema as *"Breaking changes only bump semver minor if version below 1.0.0"*. It was absent from the config, so a `feat!` would have taken 0.1.3 straight to **1.0.0**. Setting it explicitly gives `0.2.0` and, more importantly, means the next breaking change does not depend on an undocumented default either.

`0.2.0` over `1.0.0` because the verdict semantics are still being calibrated against real applications — this very PR exists because they changed. 1.0.0 would promise a stability they have not earned, and would force `2.0.0` for the next calibration.

## Follow-up

The gap that caused this is addressed separately in #22: `commitlint` validates local commit messages, which squash-merge then discards, and nothing validated the PR title — the one message that actually lands.

## Verification

`main` was checked out and verified independently of this change: typecheck clean, **344 tests passing**, with all five dependabot action bumps on top. This PR changes no source.

After merging, release-please should open a release PR proposing **0.2.0**. If it does not, something else is wrong and this diagnosis is incomplete.