### PR TITLE
ci: check the pull request title, which squash-merge turns into the commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@ updates:
     schedule:
       interval: weekly
       day: saturday
+    # Pinned rather than left to Dependabot's auto-detection of the repo's
+    # commit style: the PR title is now a required check and the input to
+    # release-please, so a heuristic guessing it wrong would block the bot.
+    commit-message:
+      prefix: chore
+      prefix-development: chore
+      include: scope
     # One grouped PR for routine bumps; majors stay individual because they
     # need actual review (this project pins measurement-sensitive versions).
     groups:
@@ -16,3 +23,6 @@ updates:
     schedule:
       interval: weekly
       day: saturday
+    commit-message:
+      prefix: chore
+      include: scope

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,57 @@
+name: PR title
+
+# Under squash-merge the pull request title *becomes* the commit message on
+# main — the branch's own commit messages survive only as bullets in the body,
+# where release-please does not look. commitlint already guards the messages
+# written locally, but those are exactly the ones squash-merge discards, so the
+# one message that reaches main was the only one nothing checked. That is how
+# the change in #20 landed unreleasable: a prose title, no version, no
+# changelog entry.
+on:
+  pull_request:
+    # `edited` matters most: it re-runs the check the moment a title is fixed.
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10.20.0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Fed through commitlint rather than a title-linting action so the rules
+      # live in one place: commitlint.config.mjs governs local commits and
+      # merged titles alike, and cannot drift between them.
+      #
+      # The title arrives via the environment, never interpolated into the
+      # script. A `${{ }}` expansion inside `run:` would let a pull request
+      # title execute shell on the runner.
+      - name: Lint the pull request title as a Conventional Commit
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "Title: $PR_TITLE"
+          if ! printf '%s\n' "$PR_TITLE" | pnpm exec commitlint; then
+            echo
+            echo "::error::The pull request title is not a Conventional Commit."
+            echo "This repository squash-merges, so this title becomes the commit"
+            echo "message on main and is what release-please reads to decide the"
+            echo "next version. A title it cannot parse means no release."
+            echo
+            echo "Examples: 'fix: stop measuring static asset routes'"
+            echo "          'feat!: scale the leak threshold with load'"
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,12 @@ Thanks for your interest in next-leak.
   silently change verdicts.
 - Every PR must pass CI (typecheck + tests on Node 22/24, macOS + Linux).
 - Conventional Commits, header ≤ 100 chars. commitlint enforces this locally.
+- **The pull request title must be a Conventional Commit too.** This repository
+  squash-merges, so the PR title — not your branch's commit messages — is what
+  lands on `main`, and it is what release-please reads to decide the next
+  version. A title it cannot parse means no version bump, no changelog entry
+  and no publish, however well-formed the commits behind it were. CI checks the
+  title against the same `commitlint.config.mjs` used for commits.
 - New behavior needs tests. Verdict-related changes also need a mutation run
   (`npm run test:mutation`) — line coverage alone has lied to us before.
 


### PR DESCRIPTION
## What

A CI check that validates the pull request title as a Conventional Commit, a note in `CONTRIBUTING.md` explaining why it matters, and a pinned commit-message prefix for Dependabot.

Companion to #21, which fixes the release that this gap broke.

## Why

`CONTRIBUTING.md` says *"Conventional Commits, header ≤ 100 chars. commitlint enforces this locally."* That is true and, under squash-merge, guards the wrong artifact: the branch's commit messages are exactly what squash-merge discards. The PR title becomes the commit on `main` and is what release-please parses — and it was the one message nothing validated.

#20 landed that way. Four conventional commits on the branch, a prose title, and a breaking change that produced no version bump, no changelog entry and no publish.

## How

The title is piped through the existing `commitlint.config.mjs` rather than a third-party title-linting action:

- one file governs local commits and merged titles alike, so the two cannot drift apart;
- it adds no dependency to a repository whose `SECURITY.md` argues its supply chain is deliberately narrow.

The title reaches the step through the environment, never interpolated into the script body. An expression expansion inside `run:` would let a pull request title execute shell on the runner.

`edited` is in the trigger list so the check re-runs the moment a title is corrected, rather than requiring an empty push.

## Dependabot

Its titles are conventional today only because Dependabot auto-detects the repository's commit style — a heuristic. With the title now a gating check, a wrong guess would block the bot, so `commit-message.prefix` is pinned explicitly for both ecosystems.

## Verification

Run against real titles from this repository's history:

| Title | Result |
|---|---|
| `fix: stop measuring static asset routes` | passes |
| `feat!: scale the leak threshold with load` | passes |
| `docs(security): document the bundle` | passes |
| `chore(deps): bump actions/checkout from 4 to 7` | passes |
| `chore(main): release 0.1.3` | passes |
| `Make the verdict reproducible, and back the public claims with gates` | **rejected** |
| `Bump actions/checkout from 4 to 7` (Dependabot's unconfigured default) | **rejected** — hence the pin above |

Both YAML files parse. The check also passed on this pull request itself, and the job log confirms it did real work rather than succeeding vacuously: the title arrived through the environment and was piped into commitlint.

## Note

Once this is merged and has run once, it is worth adding **PR title** to the repository's required status checks so the gate cannot be bypassed by merging before the check reports.