### PR TITLE
ci: let release-please read the config file it was given

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,10 +26,20 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      # No `release-type` input on purpose. Passing it puts the action in its
+      # simple mode, where it builds a config from the inputs and ignores
+      # release-please-config.json entirely — which made that file dead
+      # configuration despite being committed and schema-annotated. It is why
+      # `bump-minor-pre-major` had no effect and the first release after the
+      # breaking change in #21 came out as 1.0.0 instead of 0.2.0.
+      #
+      # Omitting it makes the action read the manifest config, whose defaults
+      # are already the files this repo has: release-please-config.json and
+      # .release-please-manifest.json. The release type still says `node` —
+      # it just lives in the config file now, where the rest of the settings
+      # can be seen and honoured alongside it.
       - uses: googleapis/release-please-action@v5
         id: release
-        with:
-          release-type: node
 
   publish:
     needs: release-please


### PR DESCRIPTION
## ⚠️ Do not merge #23 until this lands

Release PR #23 currently proposes **1.0.0**. It should be **0.2.0**. Merging it publishes 1.0.0 to npm, which cannot be undone.

Once this merges, release-please re-runs and should rewrite #23 to 0.2.0. Verify the title says `chore(main): release 0.2.0` before merging it.

## What

Removes the `release-type: node` input from the Release workflow. One line deleted.

## Why

`release-please-config.json` has been **dead configuration since it was added**. Per the [action's README](https://github.com/googleapis/release-please-action#readme), passing `release-type` selects its simple mode, which builds a config from the inputs and *ignores the config file entirely*. `changelog-path` was never read either.

Nothing in the file disagreed with the defaults, so it never showed. Then #21 added `bump-minor-pre-major: true` to get `0.2.0` out of a breaking change — and the setting was ignored along with the rest of the file. release-please proposed `1.0.0`.

This is the second layer of the same problem #21 fixed. #21 made the commit visible to release-please; this makes release-please's own configuration take effect. My change in #21 was correct in content and landed in a file nothing was reading.

## How

Dropping the input makes the action use its manifest config. The default input values are already the two files this repository has:

- `config-file` defaults to `release-please-config.json` ✅ exists
- `manifest-file` defaults to `.release-please-manifest.json` ✅ exists, reads `{".": "0.1.3"}`

The release type is unchanged — `"release-type": "node"` is already declared inside `release-please-config.json`, so it just moves from an input that suppresses the file to the file itself, where it sits next to the settings that must be honoured with it.

## Verification

The workflow was parsed to confirm the step now has no `with:` block and no `release-type` key, and both config files exist at the paths the action defaults to.

The real proof is after merge: release-please must rewrite #23 from `1.0.0` to `0.2.0`. If it does not, this diagnosis is still incomplete and should not be trusted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtVPZvLimyVnbPStRwJe4f)_