### PR TITLE
fix: keep release tags on the v0.1.3 convention the repo already published

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,8 @@
     ".": {
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "include-component-in-tag": false
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
## ⚠️ Still do not merge #23

#23 now correctly says **0.2.0** — that part worked. But its *contents* are wrong, and this fixes them. Merge this first, let release-please regenerate #23, then check it again.

## What

One line: `"include-component-in-tag": false` in `release-please-config.json`.

## Why

This is fallout from my own change in #24. Moving to the manifest config was correct, but it also changed how tags are named: `include-component-in-tag` **defaults to `true`** in manifest mode, while the simple mode it replaced did not include the component. So release-please went from `v0.1.3` to `next-leak-v0.2.0` — and then could not find any previous release under the new name.

Two things broke as a result:

**The changelog was rebuilt from the entire history.** The 0.2.0 entry currently lists **twelve** items, including things already shipped:

- `feat: CLI with reports, issue drafts and measurement confidence audit` — released in 0.1.0
- `feat: instrumented measurement ritual with post-GC heap trend verdicts` — released in 0.1.0
- `feat: snapshot diffing, leak attribution and known-cause signatures` — released in 0.1.0
- `fix: announce a duration range and stop measuring static asset routes (#11)` — released in 0.1.3

Only one line in there is actually new in 0.2.0.

**The compare link is broken.** It points at `next-leak-v0.1.3...next-leak-v0.2.0`. Neither tag exists. The four that do are `v0.1.0`, `v0.1.1`, `v0.1.2`, `v0.1.3`.

Left alone it would also publish under a tag name that breaks the existing convention — including for the Release workflow's own recovery hatch, which documents its input as *"Tag to publish (e.g. v0.1.1)"*.

## After merging

release-please re-runs and should regenerate #23 with:

- the compare link reading `v0.1.3...v0.2.0`
- **one** entry under Features, not twelve, plus the BREAKING CHANGES note
- the tag it will create being `v0.2.0`

If the changelog still lists the 0.1.0 features after this, do not merge #23 — tell me and I will look again rather than guess a third time.

## Verification

The option name, its default and its effect were read from the release-please config schema, which documents it as *"When tagging a release, include the component name as part of the tag. Defaults to `true`."* The existing tags were listed directly from the repository to confirm which convention is actually published.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtVPZvLimyVnbPStRwJe4f)_