### PR TITLE
docs: qualify what --requests changes about a verdict

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,11 @@ The verdict comes from the **shape of the post-GC curve**: retained heap that
 keeps growing every cycle is a leak; growth that flattens is warm-up. Where the
 heap sits is noise — 40 MB and 400 MB say nothing on their own — so only the
 shape is judged. The one absolute number involved is the gate a cycle's growth
-must clear to count, and it scales with the traffic that cycle served, so
-changing `--requests` changes how long the run takes and not what it decides.
+must clear to count, and above 5000 requests per cycle it scales with the
+traffic that cycle served — so in that range changing `--requests` changes how
+long the run takes and not what it decides. Below 5000 the gate stops shrinking
+and sits on the instrument's noise floor instead, so less traffic really does
+buy a less sensitive run: that is the trade `--quick` makes at 2000 requests.
 Every report prints the gate it used.
 
 ## Options
@@ -155,7 +158,9 @@ separates them, because each one has a different fix:
   is deliberately biased toward missing a leak rather than inventing one (a
   single flat or falling cycle is enough to call a route stable), so a leak
   that oscillates while it climbs can land here. To press harder, raise
-  `--cycles` and `--requests`: both make the run more sensitive. If the heap is
+  `--cycles` — every extra cycle is another delta the verdict gets to see.
+  Raising `--requests` only helps from below 5000: above that the gate scales
+  with the traffic, so the longer run decides the same thing. If the heap is
   flat but RSS keeps climbing, the report says so explicitly: that is an
   allocator, external-buffer or fragmentation problem, not a JS-heap leak.
 - **`leak`** — the report names the culprit when attribution resolves: your file (`culprit: src/app/x/page.tsx (your code)`), a dependency (package name), or framework internals. An `ISSUE-<route>.md` draft is generated; if the leak is app-owned, the draft tells you **not** to file it upstream.


### PR DESCRIPTION
The README contradicted itself about `--requests`, and the wrong half was
in the Quickstart — the part people actually read.

**Quickstart said**, with no condition attached:

> changing `--requests` changes how long the run takes and not what it decides.

**The Options table, two sections below, said:**

> Raises sensitivity as well as duration: the growth gate scales with it, down to a noise floor around 5000

## Which one is right

Both — in different regimes. `minGrowthFor()` is
`max(256 KiB, 51.2 KiB × requests/1000)`:

- **Above 5000/cycle** the rate term dominates, the gate scales with the
  traffic, and the verdict is invariant. The Quickstart claim holds.
- **At or below 5000** the noise floor dominates, the gate stops
  shrinking, and less traffic buys a genuinely less sensitive run. The
  Quickstart claim is false.

`src/trend.test.ts` already pins both regimes:

```
minGrowthFor(5000)   === MIN_GROWTH_NOISE_FLOOR === 256 KiB   // crossover, exactly
minGrowthFor(10_000) === 2 × 256 KiB
minGrowthFor(20_000) === 4 × 256 KiB
minGrowthFor(2000)   === minGrowthFor(300) === minGrowthFor(1) === 256 KiB
```

## Why it is worth fixing rather than leaving

`--quick` ships **2000 requests per cycle**. The preset we hand people
for iteration sits squarely in the regime where the Quickstart claim is
false — and the Options row for `--quick` already admits it "sits on the
noise floor and is less sensitive to slow leaks". A reader who trusts
the Quickstart concludes a `--quick` `stable` means the same thing as a
default-profile `stable`. It does not.

The comment in `trend.ts` records the bug this exact confusion caused
once already: the same route "came out `stable` at 2000 requests per
cycle and `leak` at 5000".

## Also changed

"Reading the verdicts" told readers to raise `--cycles` and `--requests`
because "both make the run more sensitive". Raising `--requests` only
helps from below 5000; above it the gate scales in step and the longer
run decides the same thing. `--cycles` is the lever that always helps,
since each extra cycle is another delta the verdict sees.

Docs only. 25 test files / 368 tests passing.

---

One related thing left alone, since it is a code change rather than a
docs change: `src/ritual.ts` on `feat/peak-pressure` carries the same
unconditional claim in a comment — "the gate scales with the traffic each
cycle served, so the verdict does not change meaning when `--requests`
does". Worth qualifying before that branch merges.

`--help` and the README also disagree about `--idle`: the README
correctly calls it a **maximum** ("the run continues as soon as the heap
settles", which is what `waitUntilSettled()` does), while `cli-args.ts`
says only "Idle seconds before each sample (default 30)". There, `--help`
is the stale surface.
