### PR TITLE
fix!: start the abandon deadline at the first byte, not at the request

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ holds it — without being told what to look for.
 | [#95094](https://github.com/vercel/next.js/issues/95094) | Middleware `setTimeout` ids retained by the sandbox | **Reproduced** · mechanism named · 112 MB retained |
 | [#94890](https://github.com/vercel/next.js/issues/94890) | Router LRU cache doesn't count its keys | **Reproduced** · 26.7 → 71.9 MB |
 | [#84884](https://github.com/vercel/next.js/issues/84884) | axios + `AbortSignal` in middleware | **Reproduced** · 32.8 → 369.9 MB |
-| [#94919](https://github.com/vercel/next.js/issues/94919) | RSC tree retained on client aborts | Not reproduced on standalone — [and it says why](#scope-and-limits-read-before-filing-issues) |
+| [#94919](https://github.com/vercel/next.js/issues/94919) | RSC tree retained on client aborts | **Reproduced** · 39 → 139 MB · [with a caveat](#scope-and-limits-read-before-filing-issues) |
 
 The full causal chain, measured on that same issue: leak found (28.7 -> 138.9 MB
 across 8 cycles), the workaround from the thread applied (`clearTimeout(id)`
@@ -269,6 +269,13 @@ through the build's source maps.
   `--max-old-space`, or every route dies as an OOM that is not the app's
   fault. When a run's heap gets close to the cap, the report says so.
 - Borderline routes can flip between `stable`/`leak` across runs — more cycles resolves this.
+- The [#94919](https://github.com/vercel/next.js/issues/94919) reproduction ships
+  a **custom Express server and deliberately no standalone output**, which this
+  tool cannot measure as published. The figure above comes from the same app
+  built with `output: "standalone"` — the leak is there too, but that is Next's
+  server under test, not the reporter's middleware chain. Instrumenting their
+  own server by hand (same `--import` bootstrap, no CLI) showed the same shape:
+  post-GC heap 43 → 56 MB and arrayBuffers 0.2 → 10.7 MB over four cycles.
 - The **peak-pressure** thresholds are calibrated against one reproduction measured in three regimes plus the bundled fixture, not against the ~40-route validation set the verdicts were tuned on. A peak note never changes a verdict, so the cost of a false one is noise, not a false accusation — but treat the exact thresholds as young.
 - The measured app runs with its real environment: routes that call external services will call them under load. Scope with `--routes` and moderate `--requests` accordingly.
 

--- a/README.md
+++ b/README.md
@@ -126,10 +126,14 @@ Dynamic routes need sample params in `next-leak.config.json` in your app dir:
   without it.
 - **`query`** appends a query string per route template
   (`{ "/api/payload/[slug]": "weightKb=2048" }`).
-- **`abandonAfterMs`** makes clients hang up before the response arrives, the
-  way closed tabs, load-balancer timeouts and bots do. Some leaks only exist
-  on that path (`ServerResponse` retained after an early disconnect). Requests
-  abandoned on purpose are not counted as failures.
+- **`abandonAfterMs`** makes clients hang up mid-response, the way closed tabs,
+  load-balancer timeouts and bots do. Some leaks only exist on that path
+  (`ServerResponse` retained after an early disconnect; the RSC tee branch in
+  [#94919](https://github.com/vercel/next.js/issues/94919)). The clock starts
+  at the **first byte of the response**, not at the request — under load a
+  request-relative window cuts before the stream begins and tests a different
+  path. Small values are the point: `4` means "read the first chunk, then
+  vanish". Requests abandoned on purpose are not counted as failures.
 
 `run.json` records what every load phase actually did — requests sent,
 2xx, abandoned — so a run can be audited instead of trusted.

--- a/src/abandon-load.test.ts
+++ b/src/abandon-load.test.ts
@@ -28,15 +28,13 @@ afterEach(async () => {
 // answering in milliseconds is never abandoned. Real leaks live on that path
 // (vercel/next.js#89091: ServerResponse retained after an early disconnect).
 describe("runAbandonPhase", () => {
-  it("hangs up before a slow response arrives", async () => {
+  it("hangs up on a route that starts streaming and never finishes", async () => {
     let started = 0;
-    let aborted = 0;
-    const port = await listen((req, res) => {
+    const port = await listen((_req, res) => {
       started += 1;
-      req.on("aborted", () => {
-        aborted += 1;
-      });
-      setTimeout(() => res.end("late"), 3000).unref();
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.write("chunk");
+      setTimeout(() => res.end("late"), 30_000).unref();
     });
 
     const result = await runAbandonPhase({
@@ -76,7 +74,8 @@ describe("runAbandonPhase", () => {
     const seen: Array<string | undefined> = [];
     const port = await listen((req, res) => {
       seen.push(req.headers["accept-encoding"] as string | undefined);
-      setTimeout(() => res.end(), 3000).unref();
+      res.write("chunk");
+      setTimeout(() => res.end(), 30_000).unref();
     });
     await runAbandonPhase({
       url: `http://127.0.0.1:${port}/x`,
@@ -97,9 +96,10 @@ describe("runAbandonPhase", () => {
 describe("abandonment accounting", () => {
   it("only counts requests that actually reached the server", async () => {
     let received = 0;
-    const port = await listen((req, res) => {
+    const port = await listen((_req, res) => {
       received += 1;
-      setTimeout(() => res.end(), 3000).unref();
+      res.write("chunk");
+      setTimeout(() => res.end(), 30_000).unref();
     });
 
     const result = await runAbandonPhase({
@@ -151,21 +151,47 @@ describe("mid-stream abandonment", () => {
     expect(result.completed).toBe(0);
   }, 60_000);
 
-  it("separates abandonment before the first byte from mid-stream", async () => {
+  // The fix for the connect-relative deadline: under load a server's first
+  // byte arrives long after any sane `abandonAfterMs`. Measured against the
+  // #94919 repro, the old timing produced 2 mid-stream cuts out of ~1500.
+  it("waits for the first byte however late it is, then cuts mid-stream", async () => {
     const port = await listen((_req, res) => {
-      // Answers far later than the abandon window: nothing is ever received.
-      setTimeout(() => res.end("late"), 30_000).unref();
+      // First byte far beyond the abandon window, exactly like a saturated
+      // route: the deadline must start here, not when the request was sent.
+      setTimeout(() => {
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.write("first chunk");
+      }, 400).unref();
+      setTimeout(() => res.end(), 30_000).unref();
     });
 
     const result = await runAbandonPhase({
       url: `http://127.0.0.1:${port}/x`,
-      amount: 20,
+      amount: 10,
       connections: 5,
-      abandonAfterMs: 100,
+      abandonAfterMs: 20,
     });
 
-    expect(result.abandoned).toBe(20);
+    expect(result.abandoned).toBe(10);
+    expect(result.abandonedMidStream).toBe(10);
+    expect(result.abandonedBeforeResponse).toBe(0);
+  }, 60_000);
+
+  it("gives up on a route that never sends a byte, counting it pre-response", async () => {
+    const port = await listen(() => {
+      // Never responds at all: only the first-byte budget can end this.
+      });
+
+    const result = await runAbandonPhase({
+      url: `http://127.0.0.1:${port}/x`,
+      amount: 4,
+      connections: 4,
+      abandonAfterMs: 10,
+    });
+
+    expect(result.abandoned).toBe(4);
     expect(result.abandonedMidStream).toBe(0);
+    expect(result.abandonedBeforeResponse).toBe(4);
   }, 60_000);
 
   it("counts a response that finished in time as completed, not abandoned", async () => {

--- a/src/abandon-load.ts
+++ b/src/abandon-load.ts
@@ -4,7 +4,7 @@ export type AbandonPhaseOptions = {
   url: string;
   amount: number;
   connections: number;
-  /** Destroy the socket this many ms after sending the request. */
+  /** Destroy the socket this many ms after the first byte of the response. */
   abandonAfterMs: number;
   headers?: Record<string, string>;
 };
@@ -18,9 +18,21 @@ export type AbandonPhaseResult = {
    * different path (the server may never have begun rendering).
    */
   abandonedMidStream: number;
+  /** Abandonments where the first-byte budget expired in silence. */
+  abandonedBeforeResponse: number;
   completed: number;
   errors: number;
 };
+
+/**
+ * How long a request waits for its first byte before being written off.
+ *
+ * Only reached by routes that are not answering, so its exact value matters
+ * little; it exists so one hung route cannot stall a phase forever. Deliberately
+ * not a flag — `--help` is not the place to explain what to do about a server
+ * that sends nothing for five seconds.
+ */
+const FIRST_BYTE_BUDGET_MS = 5000;
 
 /**
  * Sends requests and hangs up before the response arrives.
@@ -31,8 +43,8 @@ export type AbandonPhaseResult = {
  * `ServerResponse` retention to an early disconnect, which only happens when
  * a client goes away mid-flight (closed tabs, load-balancer timeouts, bots).
  *
- * Raw sockets keep this honest: write the request, wait `abandonAfterMs`,
- * destroy the socket. No response is read.
+ * Raw sockets keep this honest: write the request, wait for the response to
+ * start, then wait `abandonAfterMs` and destroy the socket mid-stream.
  */
 export async function runAbandonPhase(
   options: AbandonPhaseOptions
@@ -52,6 +64,7 @@ export async function runAbandonPhase(
     sent: 0,
     abandoned: 0,
     abandonedMidStream: 0,
+    abandonedBeforeResponse: 0,
     completed: 0,
     errors: 0,
   };
@@ -77,28 +90,36 @@ export async function runAbandonPhase(
           result.abandoned += 1;
           if (responseStarted) {
             result.abandonedMidStream += 1;
+          } else {
+            result.abandonedBeforeResponse += 1;
           }
         }
         finish();
       };
 
-      // The clock starts when the request is on the wire, not when the socket
-      // is created: under concurrency the connect itself can take longer than
-      // the abandon window, and a request never sent teaches the server
-      // nothing.
+      // Only the first-byte budget is armed here. An earlier version started
+      // the abandon window on connect, which raced the server's first byte —
+      // and under load the server lost that race almost every time: measured
+      // against the vercel/next.js#94919 repro, 2 of ~1500 cuts per cycle
+      // landed mid-stream. The window has to start where the stream does.
       socket.once("connect", () => {
         result.sent += 1;
         socket.write(request);
-        timer = setTimeout(giveUp, options.abandonAfterMs);
+        timer = setTimeout(giveUp, FIRST_BYTE_BUDGET_MS);
         timer.unref();
       });
       // Receiving bytes is not the end of the experiment, it is the start of
       // the interesting part: a client that reads a chunk and then vanishes
       // leaves the server mid-stream, which is where stream-shaped leaks live
       // (vercel/next.js#94919 retains the RSC tee branch exactly there).
-      // Closing on the first byte made that case inexpressible.
       socket.on("data", () => {
+        if (responseStarted) {
+          return;
+        }
         responseStarted = true;
+        clearTimeout(timer);
+        timer = setTimeout(giveUp, options.abandonAfterMs);
+        timer.unref();
       });
       socket.once("end", () => {
         // The server finished the response before the timer fired.

--- a/src/confidence.test.ts
+++ b/src/confidence.test.ts
@@ -426,7 +426,11 @@ describe("abandonment reaches the stream", () => {
     );
 
     expect(codesOf(result)).toEqual(["abandon-before-response"]);
-    expect(result.warnings[0]?.detail).toContain("time-to-first-byte");
+    // The old remedy ("raise abandonAfterMs above time-to-first-byte") was
+    // unfollowable under load and is now moot: the deadline starts at the
+    // first byte, so landing here means the route never answered.
+    expect(result.warnings[0]?.detail).toContain("did not start responding");
+    expect(result.warnings[0]?.detail).not.toContain("time-to-first-byte");
   });
 
   it("stays quiet when a tenth of the abandonments reached mid-stream", () => {

--- a/src/confidence.ts
+++ b/src/confidence.ts
@@ -160,15 +160,20 @@ function abandonmentWarnings(outcome: LoadOutcome): MeasurementWarning[] {
   // the server never got a byte out first. Measuring #94919 hit exactly
   // this: 1500/1500 abandoned, 1 of them mid-stream, and without saying so
   // the run reads as a clean test of a path it never touched.
+  //
+  // The remedy used to be "raise abandonAfterMs above time-to-first-byte".
+  // That advice was unfollowable — under load there is no such value — and it
+  // is now moot: the deadline starts at the first byte. Landing here means the
+  // route sent nothing at all within the first-byte budget.
   const midStream = outcome.abandonedMidStream ?? 0;
   if (abandoned > 0 && midStream < abandoned * MID_STREAM_FLOOR) {
     return [{
       code: "abandon-before-response",
       detail:
-        `${outcome.phase} cut ${abandoned} requests before the server sent ` +
-        `anything (${midStream} mid-stream) — this tested pre-response ` +
-        `disconnects, not mid-stream teardown; raise abandonAfterMs above ` +
-        `the route's time-to-first-byte`,
+        `${outcome.phase} cut ${abandoned} requests that never produced a ` +
+        `byte (${midStream} mid-stream) — the route did not start responding, ` +
+        `so mid-stream teardown was not exercised; the route is saturated or ` +
+        `hung at this load, not mistuned`,
     }];
   }
   return [];

--- a/src/heap-diff.test.ts
+++ b/src/heap-diff.test.ts
@@ -126,6 +126,52 @@ describe("diffAgainstBaseline", () => {
   });
 });
 
+// V8's roots aggregate everything below them, so the root's growth is simply
+// the heap's growth. Reporting it as a finding put `grown [synthetic] 1755 MB`
+// above the one named object on the vercel/next.js#94919 measurement.
+describe("synthetic aggregates", () => {
+  it("never reports a synthetic node as a finding", () => {
+    const root = makeNode({ id: 1, type: "synthetic", name: "", retainedSize: 100 * KB });
+    const grownRoot = makeNode({
+      id: 1,
+      type: "synthetic",
+      name: "",
+      self_size: 500 * KB,
+      retainedSize: 9000 * KB,
+    });
+    const gcRoots = makeNode({
+      id: 2,
+      type: "synthetic",
+      name: "(GC roots)",
+      retainedSize: 8000 * KB,
+    });
+    const named = makeNode({ id: 3, name: "Array", self_size: 64, retainedSize: 100 * KB });
+    const grownNamed = makeNode({ id: 3, name: "Array", self_size: 64, retainedSize: 900 * KB });
+
+    const baseline = summarizeBaseline(makeHeap([root, named]), OPTIONS);
+    const diff = diffAgainstBaseline(baseline, makeHeap([grownRoot, gcRoots, grownNamed]), OPTIONS);
+
+    const reported = [...diff.grownNodes, ...diff.newNodes];
+    expect(reported.every((finding) => finding.nodeType !== "synthetic")).toBe(true);
+    // The named object next to it is still reported.
+    expect(diff.grownNodes.map((finding) => finding.name)).toContain("Array");
+  });
+
+  it("still counts synthetic bytes in the per-type deltas", () => {
+    const before = makeNode({ id: 1, type: "synthetic", name: "", self_size: 10 * KB });
+    const after = makeNode({ id: 1, type: "synthetic", name: "", self_size: 90 * KB });
+
+    const diff = diffAgainstBaseline(
+      summarizeBaseline(makeHeap([before]), OPTIONS),
+      makeHeap([after]),
+      OPTIONS
+    );
+
+    const synthetic = diff.typeDeltas.find((delta) => delta.type === "synthetic");
+    expect(synthetic?.deltaBytes).toBe(80 * KB);
+  });
+});
+
 describe("module id harvesting", () => {
   it("collects ids from cache element edges of module instances on the chain", () => {
     const leaked = makeNode({ id: 1, name: "Leak", self_size: 4 * KB, retainedSize: 200 * KB });

--- a/src/heap-diff.ts
+++ b/src/heap-diff.ts
@@ -200,6 +200,17 @@ export function diffAgainstBaseline(
       (afterTypeSelfSizes.get(node.type) ?? 0) + node.self_size
     );
 
+    // Synthetic nodes are V8's scaffolding — the unnamed root, (GC roots),
+    // (Global handles). They name nothing and their retained size counts
+    // everything below them, so the root's delta is simply the heap's growth
+    // and it outranks every real object. Measuring vercel/next.js#94919 put
+    // `grown [synthetic] 1755.4 MB` at the top of a route whose heap grew
+    // 39 → 162 MB, with the one named object third. The chain walker already
+    // steps around these; findings must too.
+    if (node.type === "synthetic") {
+      return;
+    }
+
     if (!baseline.nodeIds.has(node.id)) {
       if (node.retainedSize >= resolved.newThresholdBytes) {
         const chain = walkChain(node, resolved.chainDepth);

--- a/src/ritual.ts
+++ b/src/ritual.ts
@@ -45,6 +45,8 @@ export type LoadOutcome = {
   abandoned?: number;
   /** Abandonments where the response had already started — the mid-stream path. */
   abandonedMidStream?: number;
+  /** Abandonments where the first-byte budget expired in silence. */
+  abandonedBeforeResponse?: number;
 };
 
 /**
@@ -322,6 +324,7 @@ export async function runRitual(
       sent: outcome.sent,
       abandoned: outcome.abandoned,
       abandonedMidStream: outcome.abandonedMidStream,
+      abandonedBeforeResponse: outcome.abandonedBeforeResponse,
       ok2xx: outcome.completed,
       errors: outcome.errors,
     });

--- a/src/route-config.ts
+++ b/src/route-config.ts
@@ -26,6 +26,11 @@ const routeConfigSchema = z
      * that path — vercel/next.js#89091 traces `ServerResponse` retention to
      * an early disconnect — and a load generator that always waits politely
      * never reaches it.
+     *
+     * Counted **from the first byte of the response**, not from the request:
+     * under load a server's first byte arrives long after any sane fixed
+     * window, so a request-relative clock cuts before the stream starts and
+     * tests the wrong path entirely.
      */
     abandonAfterMs: z.number().int().positive().optional(),
   })


### PR DESCRIPTION
Two fixes, both found by measuring the reproduction of
[vercel/next.js#94919](https://github.com/vercel/next.js/issues/94919) — an issue
Vercel confirmed and fixed this week, so the leak is ground truth rather than
this tool's opinion.

## 1. The abandon deadline raced the server's first byte

`abandonAfterMs` armed its timer when the request went on the wire. Under load
the server has not sent anything by then, so the cut landed pre-response and
never reached the mid-stream teardown the knob exists to test — the path
#94919 and #89091 live on.

Same repro, same parameters, before and after:

| | mid-stream cuts per cycle | pre-response |
|---|---|---|
| before (`abandonAfterMs: 12`, idle TTFB 9–10 ms) | 2 / 1 / 0 / 0 of ~1487 | the rest |
| after (`abandonAfterMs: 4`) | **1500 / 1500 / 1500 / 1500** of 1500 | 0 |

The deadline now starts at the first byte of the response. A separate 5 s
first-byte budget keeps a hung route from stalling a phase; requests that
exhaust it are counted as pre-response, and `abandonedBeforeResponse` is
recorded per phase in `run.json` instead of being inferred by subtraction.

The audit used to end with *"raise abandonAfterMs above the route's
time-to-first-byte"*. That advice was unfollowable — under load there is no such
value — and it is now moot: landing pre-response means the route never started
responding, which is saturation, not mistuning. The warning says that instead.

**Breaking for measurement semantics**: the same `abandonAfterMs` produces
different traffic than before, so old and new runs are not comparable. Values
should now be small — `4` means "read the first chunk, then vanish".

## 2. Root aggregates were the top finding

Synthetic nodes (the unnamed root, `(GC roots)`, `(Global handles)`) name
nothing and their retained size counts everything beneath them, so the root
always outranked real objects:

```
before: ↳ grown [synthetic]  1755.4 MB        ← the heap grew 39 → 162 MB
        ↳ grown [synthetic] (GC roots) 2.6 MB
        ↳ grown [object] system / Context 0.2 MB   ← the only real one, third

after:  ↳ grown [object] system / Context 0.2 MB — … <- Map#object[.table]
```

Findings are named objects only. Per-type deltas keep counting synthetic bytes,
where they are labelled as the aggregates they are. A route whose growth lives
in native memory now reports no findings, which is the honest answer: the curve
says how much grew, findings say what.

## 3. The README row for #94919 was stale

It claimed "not reproduced on standalone". That was a run cutting before the
first byte. It reproduces: +20.94 MB/1000 requests, post-GC heap 39 → 139 MB.
The row is corrected and now carries the caveat it needed — the repro ships a
custom Express server with no standalone output, so the measured process is
Next's server, not theirs. Their own server, instrumented by hand with the same
`--import` bootstrap, shows the same shape (heap 43 → 56 MB, arrayBuffers
0.2 → 10.7 MB over four cycles).

## Verification

typecheck · **371 tests** · build · `pack-smoke` against the installed tarball ·
the #94919 repro re-measured end to end after each change.

Note for the release: this branch carries two fixes; the changelog will only
name the PR title.