### PR TITLE
fix: stop calling healthy routes leaks, and answer the ones it cannot call

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Every report prints the gate it used.
 | `--idle <seconds>` | 30 | **Maximum** wait before each sample; the run continues as soon as the heap settles |
 | `--max-old-space <mb>` | 512 | Heap cap of each measured process. Raise it for apps whose legitimate working set is larger, or they die under measurement |
 | `--quick` | off | Fast preset (2000 requests × 4 cycles, 8s idle) — the exact profile the real-app validation ran with. Same cycle count as the default; what it trades away is traffic per cycle, so it sits on the noise floor and is less sensitive to slow leaks. Explicit flags override it |
+| `--no-resolve` | off | Skip the second pass on inconclusive routes |
 | `--diff-all` | off | Diff snapshots for stable routes too |
 | `--output <dir>` | `<app>/.next-leak` | Where runs are written |
 
@@ -168,7 +169,7 @@ separates them, because each one has a different fix:
   flat but RSS keeps climbing, the report says so explicitly: that is an
   allocator, external-buffer or fragmentation problem, not a JS-heap leak.
 - **`leak`** — the report names the culprit when attribution resolves: your file (`culprit: src/app/x/page.tsx (your code)`), a dependency (package name), or framework internals. An `ISSUE-<route>.md` draft is generated; if the leak is app-owned, the draft tells you **not** to file it upstream.
-- **`inconclusive`** — sustained sub-threshold growth: measure longer. The CLI prints the exact re-run command (`--routes <those> --cycles 6`).
+- **`inconclusive`** — the evidence does not decide. The run does not stop there: any inconclusive route is **measured again automatically**, with twice the cycles, and the second pass is what you see (`resolved at 8 cycles` next to the verdict). On the reproduction for [#95094](https://github.com/vercel/next.js/issues/95094), `--quick` alone reports `inconclusive` on three deltas and then comes back with the leak. `--no-resolve` turns the second pass off; when even that is undecided, the re-run command is still printed.
 - **`failed`** — the route errored under load (auth redirects, POST-only endpoints). >1% non-2xx aborts measurement instead of measuring garbage. That's by design.
 
 ## Peak pressure: `stable` is not the same as safe

--- a/src/abandon-load.test.ts
+++ b/src/abandon-load.test.ts
@@ -282,7 +282,10 @@ describe("mid-stream abandonment", () => {
 
   // Also from mutation testing: an unhandled socket error left the request
   // promise pending forever, which would hang a load phase rather than fail it.
-  it("counts a socket error and still finishes the phase", async () => {
+  // What a hang-up looks like to the client is platform-dependent — macOS
+  // reports an error where Linux sees a clean close — so the invariant worth
+  // asserting is that the phase ends and every request is accounted for.
+  it("finishes the phase when the server hangs up on every connection", async () => {
     const port = await listen(() => {
       // Never responds; the socket is destroyed from the server side below.
     });
@@ -297,8 +300,7 @@ describe("mid-stream abandonment", () => {
       abandonAfterMs: 10,
     });
 
-    expect(result.errors + result.abandoned).toBeGreaterThan(0);
-    expect(result.completed).toBe(0);
+    expect(result.errors + result.abandoned + result.completed).toBe(4);
   }, 30_000);
 
   it("gives up on a route that never sends a byte, counting it pre-response", async () => {

--- a/src/abandon-load.test.ts
+++ b/src/abandon-load.test.ts
@@ -125,6 +125,77 @@ describe("abandonment accounting", () => {
   }, 60_000);
 });
 
+// Mutation survivors that mattered: a wrong header join corrupts the request,
+// an unhandled connect error hangs the phase, and losing the concurrency cap
+// silently turns `--connections 24` into 1500 sockets.
+describe("request shape and limits", () => {
+  it("sends every configured header on its own line", async () => {
+    const seen: Array<Record<string, string | string[] | undefined>> = [];
+    const port = await listen((req, res) => {
+      seen.push(req.headers);
+      res.write("chunk");
+      setTimeout(() => res.end(), 30_000).unref();
+    });
+
+    await runAbandonPhase({
+      url: `http://127.0.0.1:${port}/x`,
+      amount: 2,
+      connections: 1,
+      abandonAfterMs: 20,
+      headers: { "accept-encoding": "gzip", "x-probe": "yes" },
+    });
+
+    expect(seen).toHaveLength(2);
+    expect(seen[0]?.["accept-encoding"]).toBe("gzip");
+    expect(seen[0]?.["x-probe"]).toBe("yes");
+  }, 30_000);
+
+  it("counts connect errors instead of hanging the phase", async () => {
+    const port = await listen(() => undefined);
+    await new Promise<void>((resolve) => server?.close(() => resolve()));
+    server = undefined;
+
+    const result = await runAbandonPhase({
+      url: `http://127.0.0.1:${port}/x`,
+      amount: 4,
+      connections: 2,
+      abandonAfterMs: 10,
+    });
+
+    expect(result.errors).toBe(4);
+    expect(result.sent).toBe(0);
+    expect(result.completed).toBe(0);
+  }, 30_000);
+
+  it("never opens more sockets at once than the configured connections", async () => {
+    let open = 0;
+    let peak = 0;
+    const port = await listen((_req, res) => {
+      res.write("chunk");
+      setTimeout(() => res.end(), 30_000).unref();
+    });
+    server?.on("connection", (socket) => {
+      open += 1;
+      peak = Math.max(peak, open);
+      socket.once("close", () => {
+        open -= 1;
+      });
+    });
+
+    await runAbandonPhase({
+      url: `http://127.0.0.1:${port}/x`,
+      amount: 40,
+      connections: 4,
+      abandonAfterMs: 15,
+    });
+
+    // One over the cap is the socket already destroyed whose `close` has not
+    // propagated to the server yet; the in-flight requests are still 4. What
+    // this guards against is the cap being ignored altogether (40 at once).
+    expect(peak).toBeLessThanOrEqual(5);
+  }, 60_000);
+});
+
 // vercel/next.js#94919 retains the RSC stream's tee branch when a client
 // reads part of a response and disappears. Closing on the first byte made
 // that scenario impossible to reproduce: the run only ever tested clients
@@ -176,6 +247,59 @@ describe("mid-stream abandonment", () => {
     expect(result.abandonedMidStream).toBe(10);
     expect(result.abandonedBeforeResponse).toBe(0);
   }, 60_000);
+
+  // Caught by mutation testing: without the early return in the data handler,
+  // every chunk re-arms the timer and the cut lands `abandonAfterMs` after the
+  // LAST byte instead of the first — on a stream that keeps sending, that is
+  // never. The deadline must be relative to the start of the response.
+  it("cuts relative to the first byte, not the last, on a chunked stream", async () => {
+    const port = await listen((_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.write("first");
+      // Keeps sending well past the abandon window; a last-byte-relative
+      // deadline would never fire while this runs.
+      const chunker = setInterval(() => res.write("more"), 20);
+      chunker.unref();
+      setTimeout(() => {
+        clearInterval(chunker);
+        res.end();
+      }, 30_000).unref();
+    });
+
+    const started = Date.now();
+    const result = await runAbandonPhase({
+      url: `http://127.0.0.1:${port}/x`,
+      amount: 6,
+      connections: 3,
+      abandonAfterMs: 30,
+    });
+
+    expect(result.abandonedMidStream).toBe(6);
+    expect(result.completed).toBe(0);
+    // Two rounds of ~30ms cuts, not two rounds of "whenever the stream stops".
+    expect(Date.now() - started).toBeLessThan(5000);
+  }, 60_000);
+
+  // Also from mutation testing: an unhandled socket error left the request
+  // promise pending forever, which would hang a load phase rather than fail it.
+  it("counts a socket error and still finishes the phase", async () => {
+    const port = await listen(() => {
+      // Never responds; the socket is destroyed from the server side below.
+    });
+    server?.on("connection", (socket) => {
+      socket.destroy(new Error("boom"));
+    });
+
+    const result = await runAbandonPhase({
+      url: `http://127.0.0.1:${port}/x`,
+      amount: 4,
+      connections: 2,
+      abandonAfterMs: 10,
+    });
+
+    expect(result.errors + result.abandoned).toBeGreaterThan(0);
+    expect(result.completed).toBe(0);
+  }, 30_000);
 
   it("gives up on a route that never sends a byte, counting it pre-response", async () => {
     const port = await listen(() => {

--- a/src/cli-args.test.ts
+++ b/src/cli-args.test.ts
@@ -15,6 +15,7 @@ describe("parseCliArgs", () => {
         idleSeconds: null,
         maxOldSpaceMb: null,
         quick: false,
+        noResolve: false,
         diffAll: false,
         output: null,
       },
@@ -25,7 +26,7 @@ describe("parseCliArgs", () => {
     const parsed = parseCliArgs([
       "app", "--routes", "/api,/dashboard", "--cycles", "6", "--requests", "1000",
       "--connections", "20", "--idle", "8", "--max-old-space", "2048", "--quick",
-      "--diff-all", "--output", "/tmp/out",
+      "--diff-all", "--no-resolve", "--output", "/tmp/out",
     ]);
     if (parsed.kind !== "run") {
       throw new Error(`expected run, got ${parsed.kind}`);
@@ -39,6 +40,7 @@ describe("parseCliArgs", () => {
       idleSeconds: 8,
       maxOldSpaceMb: 2048,
       quick: true,
+      noResolve: true,
       diffAll: true,
       output: "/tmp/out",
     });

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -7,6 +7,7 @@ export type CliRunOptions = {
   idleSeconds: number | null;
   maxOldSpaceMb: number | null;
   quick: boolean;
+  noResolve: boolean;
   diffAll: boolean;
   output: string | null;
 };
@@ -49,6 +50,11 @@ const FLAGS: FlagSpec[] = [
     help: "Fast preset: 2000 requests x 4 cycles, 8s idle — same cycle count as the default, less traffic per cycle",
   },
   { flag: "--diff-all", value: "none", help: "Diff snapshots for stable routes too (slow)" },
+  {
+    flag: "--no-resolve",
+    value: "none",
+    help: "Do not re-measure inconclusive routes with more cycles (default: re-measure once)",
+  },
   { flag: "--output", value: "string", argName: "<dir>", help: "Where to write runs (default <app-dir>/.next-leak)" },
   { flag: "--help", alias: "-h", value: "none", help: "Show this help" },
   { flag: "--version", alias: "-v", value: "none", help: "Print the version" },
@@ -162,6 +168,9 @@ function applyFlag(spec: FlagSpec, value: string, options: CliRunOptions): FlagO
     case "--diff-all":
       options.diffAll = true;
       return FLAG_OK;
+    case "--no-resolve":
+      options.noResolve = true;
+      return FLAG_OK;
     case "--output":
       options.output = value;
       return FLAG_OK;
@@ -220,6 +229,7 @@ export function parseCliArgs(argv: string[]): ParsedCli {
     idleSeconds: null,
     maxOldSpaceMb: null,
     quick: false,
+    noResolve: false,
     diffAll: false,
     output: null,
   };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -121,6 +121,7 @@ async function main(): Promise<void> {
     ...(options.idleSeconds !== null && { idleMs: options.idleSeconds * 1000 }),
     ...(options.maxOldSpaceMb !== null && { maxOldSpaceMb: options.maxOldSpaceMb }),
     ...(options.diffAll && { diffAll: true }),
+    ...(options.noResolve && { resolveInconclusive: false }),
     ...(options.output !== null && { outputDir: options.output }),
     onProgress: (message) => console.error(`· ${message}`),
   });

--- a/src/confidence.test.ts
+++ b/src/confidence.test.ts
@@ -232,11 +232,12 @@ describe("abandonment auditing", () => {
 
 describe("growth shape auditing", () => {
   it("accepts a 4x spread between cycles and warns just beyond it", () => {
+    const pad = [2 * MB, 2 * MB, 2 * MB];
     const at = assessConfidence(
-      input({ trend: trend({ deltas: [1 * MB, 4 * MB], growthPerCycle: 2.5 * MB }) })
+      input({ trend: trend({ deltas: [1 * MB, 4 * MB, ...pad], growthPerCycle: 2.5 * MB }) })
     );
     const beyond = assessConfidence(
-      input({ trend: trend({ deltas: [1 * MB, 4 * MB + 1], growthPerCycle: 2.5 * MB }) })
+      input({ trend: trend({ deltas: [1 * MB, 4 * MB + 1, ...pad], growthPerCycle: 2.5 * MB }) })
     );
 
     expect(codesOf(at)).toEqual([]);
@@ -292,7 +293,7 @@ describe("noise floor auditing", () => {
       input({
         trend: trend({
           growthPerCycle: 2 * MIN_GROWTH,
-          deltas: [2 * MIN_GROWTH, 2 * MIN_GROWTH],
+          deltas: Array.from({ length: 5 }, () => 2 * MIN_GROWTH),
         }),
       })
     );
@@ -300,7 +301,7 @@ describe("noise floor auditing", () => {
       input({
         trend: trend({
           growthPerCycle: 2 * MIN_GROWTH - 1,
-          deltas: [2 * MIN_GROWTH - 1, 2 * MIN_GROWTH - 1],
+          deltas: Array.from({ length: 5 }, () => 2 * MIN_GROWTH - 1),
         }),
       })
     );
@@ -313,7 +314,10 @@ describe("noise floor auditing", () => {
     const result = assessConfidence(
       input({
         minGrowthPerCycle: 4 * MB,
-        trend: trend({ growthPerCycle: 5 * MB, deltas: [5 * MB, 5 * MB] }),
+        trend: trend({
+          growthPerCycle: 5 * MB,
+          deltas: Array.from({ length: 5 }, () => 5 * MB),
+        }),
       })
     );
 
@@ -414,6 +418,93 @@ describe("heap ceiling audit", () => {
 
 // Measuring vercel/next.js#94919: 1500/1500 abandoned, 1 of them mid-stream.
 // The run looked like a clean test of stream teardown and had not touched it.
+// Measured 2026-07-26 on the app from vercel/next.js#94919 with --quick:
+// three of nine healthy routes came back `leak`, two with an issue draft, and
+// a repeat run disagreed with itself. Three deltas cannot carry an accusation
+// unless the growth is far larger than the noise that produced them.
+describe("a leak needs evidence proportional to its size", () => {
+  const MB = 1024 * 1024;
+  const gate = 256 * 1024;
+
+  const leakFrom = (deltas: number[]) => ({
+    verdict: "leak" as const,
+    growthPerCycle: deltas.reduce((sum, d) => sum + d, 0) / deltas.length,
+    deltas,
+    source: "heap" as const,
+  });
+
+  const audit = (deltas: number[]) =>
+    assessConfidence({
+      trend: leakFrom(deltas),
+      loadOutcomes: [{ phase: "cycle 1", sent: 2000, ok2xx: 2000 }],
+      settleOutcomes: [{ phase: "cycle 1", status: "settled", polls: 2 }],
+      minGrowthPerCycle: gate,
+    });
+
+  it("withdraws /missing, the false positive that shipped an issue draft", () => {
+    // The measured series: +3.43, -0.03, +2.76 MB over three deltas.
+    const result = audit([3.43 * MB, -0.03 * MB, 2.76 * MB]);
+    expect(result.supersededVerdict).toBe("inconclusive");
+    expect(codesOf(result)).toContain("thin-evidence");
+    expect(
+      warrantsIssueDraft({ trend: leakFrom([3.43 * MB, -0.03 * MB, 2.76 * MB]), confidence: result })
+    ).toBe(false);
+  });
+
+  it("withdraws the other two measured false positives", () => {
+    // /product-fail heap and /client-plp external, same run.
+    expect(audit([1.41 * MB, 2.78 * MB, 0.61 * MB]).supersededVerdict).toBe("inconclusive");
+    expect(audit([1.09 * MB, 2.02 * MB, 0.0]).supersededVerdict).toBe("inconclusive");
+  });
+
+  it("leaves #94919 alone: three deltas, but a hundred times the gate", () => {
+    const result = audit([25.6 * MB, 25.02 * MB, 24.77 * MB]);
+    expect(result.supersededVerdict).toBeUndefined();
+    expect(codesOf(result)).not.toContain("thin-evidence");
+  });
+
+  it("leaves #95094 alone: a stepwise leak measured over enough cycles", () => {
+    // canary.96, six cycles: +12.51, +11.24, +0.10, +16.83, +0.00 MB. Flat
+    // cycles are the shape of a stepwise leak; five deltas is the evidence
+    // that makes them believable.
+    const result = audit([12.51 * MB, 11.24 * MB, 0.1 * MB, 16.83 * MB, 0.0]);
+    expect(result.supersededVerdict).toBeUndefined();
+  });
+
+  it("accepts modest growth once there are enough cycles to trust it", () => {
+    // Same magnitude as the false positives, five deltas instead of three.
+    const result = audit([1.4 * MB, 2.8 * MB, 0.6 * MB, 1.2 * MB, 0.9 * MB]);
+    expect(result.supersededVerdict).toBeUndefined();
+  });
+
+  it("keeps the bundled fixture, which grows every cycle by design", () => {
+    // 8 KB retained per request x 300 requests = ~2.4 MB per cycle, on two
+    // deltas. Modest against the gate on average, but no cycle gives it back.
+    const result = audit([2.4 * MB, 2.3 * MB]);
+    expect(result.supersededVerdict).toBeUndefined();
+  });
+
+  it("says how many cycles and how far above the gate", () => {
+    const detail = audit([3.43 * MB, -0.03 * MB, 2.76 * MB]).warnings.find(
+      (warning) => warning.code === "thin-evidence"
+    )?.detail;
+    expect(detail).toContain("3 cycles");
+    expect(detail).toContain("weakest");
+    expect(detail).toContain("measure more cycles");
+  });
+
+  it("never touches a stable verdict", () => {
+    const result = assessConfidence({
+      trend: { verdict: "stable", growthPerCycle: 0.1 * MB, deltas: [0.1 * MB, -0.2 * MB], source: "heap" },
+      loadOutcomes: [{ phase: "cycle 1", sent: 2000, ok2xx: 2000 }],
+      settleOutcomes: [{ phase: "cycle 1", status: "settled", polls: 2 }],
+      minGrowthPerCycle: gate,
+    });
+    expect(result.supersededVerdict).toBeUndefined();
+    expect(codesOf(result)).not.toContain("thin-evidence");
+  });
+});
+
 describe("abandonment reaches the stream", () => {
   it("warns when everything was cut before the server responded", () => {
     const result = assessConfidence(

--- a/src/confidence.ts
+++ b/src/confidence.ts
@@ -13,6 +13,7 @@ import { MIN_GROWTH_NOISE_FLOOR, type TrendResult, type TrendVerdict } from "./t
  *   mid-stream teardown path was never reached
  * `spiky-growth`        — one cycle dominates, so the mean describes little
  * `near-threshold`      — growth barely clears the noise floor
+ * `thin-evidence`       — a leak called on too few cycles for its size
  * `near-heap-ceiling`   — the heap approached the cap the process ran under,
  *   so the curve was measured against a ceiling instead of running free
  */
@@ -24,6 +25,7 @@ export type WarningCode =
   | "abandon-before-response"
   | "spiky-growth"
   | "near-threshold"
+  | "thin-evidence"
   | "near-heap-ceiling";
 
 export type MeasurementWarning = {
@@ -83,6 +85,7 @@ export function effectiveVerdict(report: {
 const VERDICT_WEAKENING: ReadonlySet<WarningCode> = new Set([
   "near-threshold",
   "spiky-growth",
+  "thin-evidence",
 ]);
 
 /**
@@ -282,6 +285,56 @@ function heapCeilingWarnings(input: ConfidenceInput): MeasurementWarning[] {
  * only an *observed* moving heap invalidates: "unverified" means the run
  * never looked, which is a reason to say so, not to overturn the reading.
  */
+/**
+ * Deltas below which a leak verdict has to be large to be believed.
+ *
+ * Four cycles leave three deltas after the warm-up one is dropped, and three
+ * points of a heap oscillating a couple of MB around its plateau satisfy both
+ * leak shapes. Measured on 2026-07-26 against the app from vercel/next.js#94919
+ * with `--quick`: three of nine healthy routes came back `leak`, two of them
+ * with an issue draft, and a repeat run returned `stable` for two of the three.
+ */
+const THIN_EVIDENCE_MIN_DELTAS = 5;
+
+/**
+ * What every cycle must grow, as a multiple of the gate, for a leak called on
+ * thin evidence to stand.
+ *
+ * The mean is the wrong test here: the false positives averaged 4.1-8.2x the
+ * gate, and so does the bundled leaky fixture, which retains 8 KB per request
+ * by construction. What separates them is the *worst* cycle. The false
+ * positives all contain a cycle that gave memory back or stood still
+ * (-0.03 MB, 0.00 MB, +0.08 MB); a real leak measured on three deltas grows
+ * every one of them — the fixture by ~2.4 MB (9x), #94919 by ~25 MB (99x).
+ */
+const THIN_EVIDENCE_MIN_DELTA_RATIO = 4;
+
+function isThinEvidence(trend: TrendResult, minGrowth: number): boolean {
+  if (trend.deltas.length >= THIN_EVIDENCE_MIN_DELTAS || trend.deltas.length === 0) {
+    return false;
+  }
+  const smallest = Math.min(...trend.deltas);
+  return smallest < minGrowth * THIN_EVIDENCE_MIN_DELTA_RATIO;
+}
+
+function thinEvidenceWarnings(
+  trend: TrendResult,
+  minGrowth: number
+): MeasurementWarning[] {
+  if (trend.verdict !== "leak" || !isThinEvidence(trend, minGrowth)) {
+    return [];
+  }
+  const smallest = Math.min(...trend.deltas);
+  return [{
+    code: "thin-evidence",
+    detail:
+      `judged on ${trend.deltas.length} cycles, and its weakest grew ` +
+      `${mb(smallest)} against a ${mb(minGrowth)} gate — on that few cycles ` +
+      `ordinary oscillation reaches that, and a repeat run often disagrees; ` +
+      `measure more cycles to resolve it`,
+  }];
+}
+
 function isVerdictInvalid(input: ConfidenceInput): boolean {
   if (input.trend.verdict !== "leak") {
     return false;
@@ -293,7 +346,11 @@ function isVerdictInvalid(input: ConfidenceInput): boolean {
     input.abandonAfterMs !== undefined &&
     input.loadOutcomes.length > 0 &&
     input.loadOutcomes.every((outcome) => (outcome.abandoned ?? 0) === 0);
-  return neverSettled || abandonedNothing;
+  const thinEvidence = isThinEvidence(
+    input.trend,
+    input.minGrowthPerCycle ?? MIN_GROWTH_NOISE_FLOOR
+  );
+  return neverSettled || abandonedNothing || thinEvidence;
 }
 
 /**
@@ -312,6 +369,7 @@ export function assessConfidence(input: ConfidenceInput): ConfidenceReport {
     ...loadWarnings(input.loadOutcomes, input.abandonAfterMs),
     ...growthShapeWarnings(input.trend),
     ...noiseFloorWarnings(input.trend, minGrowth),
+    ...thinEvidenceWarnings(input.trend, minGrowth),
     ...heapCeilingWarnings(input),
   ];
 

--- a/src/report.test.ts
+++ b/src/report.test.ts
@@ -44,6 +44,18 @@ describe("formatReport", () => {
     expect(output).toContain("next-leak /apps/shop --routes / --cycles 8");
   });
 
+  it("says which cycle count a resolved verdict was judged over", () => {
+    const report = makeRunReport();
+    const healthy = report.routes[0];
+    if (healthy?.status !== "measured") throw new Error("fixture broken");
+    healthy.resolvedWithCycles = 8;
+    const output = formatReport(report);
+    expect(output).toContain("(resolved at 8 cycles)");
+    // The footer quotes the run's figure and the resolved one, not just the
+    // parameter the user passed.
+    expect(output).toContain("judged over 4 cycles (8 where resolved)");
+  });
+
   it("prints no hint when nothing is inconclusive", () => {
     expect(formatReport(makeRunReport())).not.toContain("hint:");
   });

--- a/src/report.ts
+++ b/src/report.ts
@@ -153,10 +153,16 @@ function routeLines(route: RouteReport, parameters: RunParameters): string[] {
 
   const verdict = effectiveVerdict(route);
   const curve = route.samples.map(formatMb).join(" → ");
+  // A verdict the run had to go back for is not the same claim as one it got
+  // first time; saying so is the difference between a number and its provenance.
+  const resolved =
+    route.resolvedWithCycles === undefined
+      ? ""
+      : `  (resolved at ${route.resolvedWithCycles} cycles)`;
   return [
     `  ${VERDICT_ICON[verdict]} ${route.route}  ${verdict}  (${formatGrowth(
       route.growthPer1000Requests
-    )})  heap ${curve}`,
+    )})  heap ${curve}${resolved}`,
     ...confidenceLines(route),
     ...memorySourceLines(route, verdict),
     ...peakPressureLines(route, parameters),
@@ -173,9 +179,24 @@ export function formatReport(report: RunReport): string {
   // A verdict whose gate is not printed cannot be reproduced: the same route
   // judged against a different threshold is a different measurement.
   const { minGrowthPerCycle, loadRequests, cycles, maxOldSpaceMb } = report.parameters;
+  // Routes that needed a second pass were judged over more cycles than the run
+  // asked for; a footer quoting only the run's figure describes neither.
+  const resolvedCycles = [
+    ...new Set(
+      report.routes.flatMap((route) =>
+        route.status === "measured" && route.resolvedWithCycles !== undefined
+          ? [route.resolvedWithCycles]
+          : []
+      )
+    ),
+  ].sort((a, b) => a - b);
+  const cyclesLabel =
+    resolvedCycles.length === 0
+      ? `${cycles} cycles`
+      : `${cycles} cycles (${resolvedCycles.join(", ")} where resolved)`;
   lines.push(
     "",
-    `judged over ${cycles} cycles × ${loadRequests} requests, growth gate ` +
+    `judged over ${cyclesLabel} × ${loadRequests} requests, growth gate ` +
       `${(minGrowthPerCycle / 1024).toFixed(0)} KiB/cycle ` +
       `(${formatGrowth((minGrowthPerCycle / loadRequests) * 1000)}), heap cap ${maxOldSpaceMb} MB`,
     `snapshots and run.json: ${report.workDir}`,

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -143,6 +143,100 @@ describe("estimateRun", () => {
   });
 });
 
+// `inconclusive` is the verdict that asks the user to run the tool again. On
+// the vercel/next.js#95094 repro at --quick it lands on a real leak: three
+// deltas cannot carry it, six can. The run goes back for the evidence itself.
+describe("resolving inconclusive routes", () => {
+  const inconclusive = (route: string): RitualResult => ({
+    ...ritualResult(route, [30 * MB, 31 * MB, 31 * MB, 32 * MB]),
+    trend: { verdict: "inconclusive", growthPerCycle: 0.4 * MB, deltas: [0, 0.4 * MB], source: "heap" },
+  });
+  const leaking = (route: string): RitualResult => ({
+    ...ritualResult(route, [30 * MB, 40 * MB, 50 * MB, 60 * MB, 70 * MB, 80 * MB, 90 * MB]),
+    trend: {
+      verdict: "leak",
+      growthPerCycle: 10 * MB,
+      deltas: Array.from({ length: 5 }, () => 10 * MB),
+      source: "heap",
+    },
+  });
+
+  it("measures again with more cycles and reports the resolved verdict", async () => {
+    const appDir = await makeAppDir({ "/page": "app/page.js" });
+    const calls: Array<number | undefined> = [];
+    const report = await runMeasurement(
+      { appDir, bootstrapPath: "/fake/bootstrap.js", routeFilter: ["/"] },
+      {
+        ...makeDeps([]),
+        ritual: async (options) => {
+          calls.push(options.cycles);
+          return calls.length === 1 ? inconclusive(options.route) : leaking(options.route);
+        },
+      }
+    );
+
+    const route = report.routes.find((entry) => entry.route === "/");
+    if (route?.status !== "measured") throw new Error("route should be measured");
+    expect(route.trend.verdict).toBe("leak");
+    expect(route.resolvedWithCycles).toBe(8);
+    // Default is 4 cycles; the second pass uses the figure the report tells a
+    // user to pass by hand.
+    expect(calls).toEqual([undefined, 8]);
+  });
+
+  it("leaves decided routes alone", async () => {
+    const appDir = await makeAppDir({ "/page": "app/page.js" });
+    let calls = 0;
+    await runMeasurement(
+      { appDir, bootstrapPath: "/fake/bootstrap.js", routeFilter: ["/"] },
+      {
+        ...makeDeps([]),
+        ritual: async (options) => {
+          calls += 1;
+          return leaking(options.route);
+        },
+      }
+    );
+    expect(calls).toBe(1);
+  });
+
+  it("does not go back when the user said not to", async () => {
+    const appDir = await makeAppDir({ "/page": "app/page.js" });
+    let calls = 0;
+    const report = await runMeasurement(
+      {
+        appDir,
+        bootstrapPath: "/fake/bootstrap.js",
+        routeFilter: ["/"],
+        resolveInconclusive: false,
+      },
+      {
+        ...makeDeps([]),
+        ritual: async (options) => {
+          calls += 1;
+          return inconclusive(options.route);
+        },
+      }
+    );
+    expect(calls).toBe(1);
+    const route = report.routes.find((entry) => entry.route === "/");
+    if (route?.status !== "measured") throw new Error("route should be measured");
+    expect(route.resolvedWithCycles).toBeUndefined();
+  });
+
+  it("reports the second pass when it is still undecided", async () => {
+    const appDir = await makeAppDir({ "/page": "app/page.js" });
+    const report = await runMeasurement(
+      { appDir, bootstrapPath: "/fake/bootstrap.js", routeFilter: ["/"] },
+      { ...makeDeps([]), ritual: async (options) => inconclusive(options.route) }
+    );
+    const route = report.routes.find((entry) => entry.route === "/");
+    if (route?.status !== "measured") throw new Error("route should be measured");
+    expect(route.trend.verdict).toBe("inconclusive");
+    expect(route.resolvedWithCycles).toBe(8);
+  });
+});
+
 describe("runMeasurement", () => {
   it("measures static routes, skips dynamic ones, and survives failing routes", async () => {
     const appDir = await makeAppDir({

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { attributeDiff, type AttributedDiff } from "./attribution.js";
 import {
   assessConfidence,
+  effectiveVerdict,
   warrantsIssueDraft,
   type ConfidenceReport,
 } from "./confidence.js";
@@ -71,6 +72,11 @@ export type RouteReport =
       /** Null when there is no diff or no module registry. */
       attribution: AttributedDiff | null;
       signatures: MatchedSignature[];
+      /**
+       * Cycles used by the second pass, when the first came back
+       * `inconclusive` and the run went back for more evidence.
+       */
+      resolvedWithCycles?: number;
     };
 
 export type MeasuredRoute = Extract<RouteReport, { status: "measured" }>;
@@ -125,6 +131,11 @@ export type RunOptions = {
   diffAll?: boolean;
   /** Only measure routes matching these templates or prefixes. */
   routeFilter?: string[];
+  /**
+   * Measure a route again, with more cycles, when the first pass could not
+   * call it. Default true: the run should answer the question it was asked.
+   */
+  resolveInconclusive?: boolean;
   /** Abort between phases; remaining routes are reported as interrupted. */
   signal?: AbortSignal;
   onProgress?: (message: string) => void;
@@ -322,19 +333,25 @@ async function measureRoute(
   context: MeasurementContext,
   route: DiscoveredRoute,
   requestPath: string,
-  index: number
+  index: number,
+  pass: { cycles: number; dirSuffix: string } | undefined = undefined
 ): Promise<RouteReport> {
   const { deps, options, target, workDir, routeConfig, registry, nextVersion, progress } = context;
   const result = await deps.ritual({
     serverPath: target.standaloneServer,
     route: requestPath,
-    workDir: path.join(workDir, `${String(index + 1).padStart(2, "0")}-${routeSlug(route.path)}`),
+    workDir: path.join(
+      workDir,
+      `${String(index + 1).padStart(2, "0")}-${routeSlug(route.path)}${pass?.dirSuffix ?? ""}`
+    ),
     bootstrapPath: options.bootstrapPath,
     appPort: await deps.freePort(),
     ...(options.warmupRequests !== undefined && { warmupRequests: options.warmupRequests }),
     ...(options.loadRequests !== undefined && { loadRequests: options.loadRequests }),
     ...(options.connections !== undefined && { connections: options.connections }),
-    ...(options.cycles !== undefined && { cycles: options.cycles }),
+    ...(pass !== undefined
+      ? { cycles: pass.cycles }
+      : options.cycles !== undefined && { cycles: options.cycles }),
     ...(options.idleMs !== undefined && { idleMs: options.idleMs }),
     ...(options.maxOldSpaceMb !== undefined && { maxOldSpaceMb: options.maxOldSpaceMb }),
     ...(routeConfig.headers !== undefined && { headers: routeConfig.headers }),
@@ -374,6 +391,7 @@ async function measureRoute(
     route: route.path,
     status: "measured",
     requestPath,
+    ...(pass !== undefined && { resolvedWithCycles: pass.cycles }),
     samples: result.samples,
     memorySamples: result.memorySamples,
     peaks: result.peaks,
@@ -409,6 +427,12 @@ async function writeEvidenceBundle(report: RunReport, workDir: string): Promise<
   await writeFile(report.bundle.htmlReport, renderHtmlReport(report));
 }
 
+/**
+ * Cycles a second pass uses — the same figure the report recommends for a
+ * manual re-run, so the tool follows its own advice.
+ */
+export const resolveCycles = (cycles: number): number => Math.max(cycles * 2, 6);
+
 /** Skip, measure or record the failure for one route — never throws. */
 async function routeReportFor(
   context: MeasurementContext,
@@ -427,7 +451,24 @@ async function routeReportFor(
   try {
     const asPath = requestPath === route.path ? "" : ` as ${requestPath}`;
     progress(`measuring ${label}${asPath}`);
-    return await measureRoute(context, route, requestPath, index);
+    const first = await measureRoute(context, route, requestPath, index);
+    if (
+      first.status !== "measured" ||
+      context.options.resolveInconclusive === false ||
+      effectiveVerdict(first) !== "inconclusive"
+    ) {
+      return first;
+    }
+    // `inconclusive` means "the evidence does not decide" and the report knows
+    // exactly what would: the same route, twice the cycles. Printing that
+    // command and stopping asks someone whose pods are restarting to run the
+    // tool twice; going and getting the evidence is the answer they came for.
+    const cycles = resolveCycles(context.options.cycles ?? RITUAL_DEFAULTS.cycles);
+    progress(`re-measuring ${route.path} with ${cycles} cycles: the first pass could not call it`);
+    return await measureRoute(context, route, requestPath, index, {
+      cycles,
+      dirSuffix: "-resolve",
+    });
   } catch (cause) {
     const failure = cause instanceof Error ? cause.message : String(cause);
     progress(`failed ${label}: ${failure}`);
@@ -488,6 +529,9 @@ async function planRun(
     `${routes.length} routes discovered` +
       (measurable === routes.length ? "" : ` · ${measurable} measurable`) +
       ` · estimated ${formatEstimate(estimate)}` +
+      (options.resolveInconclusive === false
+        ? ""
+        : " (inconclusive routes are measured again)") +
       // Long default runs are where first-time users give up; point at the two
       // ways out. Suppressed once load parameters were tuned by hand (or by
       // --quick, which arrives here as explicit loadRequests/idleMs).

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -33,7 +33,8 @@
     "src/target.ts",
     "src/environment.ts",
     "src/confidence.ts",
-    "src/peak-pressure.ts"
+    "src/peak-pressure.ts",
+    "src/abandon-load.ts"
   ],
   "thresholds": {
     "high": 90,


### PR DESCRIPTION
Found by running the tool the way someone who just installed it would: whole
app, `--quick`, no route filter, against the reproduction app for
[vercel/next.js#94919](https://github.com/vercel/next.js/issues/94919).

**Three of nine healthy routes came back `leak`, and two of them shipped an
`ISSUE-*.md` draft** — the tool invited its user to file a bug against Next.js
for noise. A repeat `--quick` run disagreed with itself on two of the three.
Measured at eight cycles, all three are stable:

| route | `--quick` (4 cycles) | 8 cycles |
|---|---|---|
| `/client-plp` | leak +0.52 MB/1000 req | stable +0.13 |
| `/missing` | leak +1.03 | stable +0.01 |
| `/product-fail` | leak +0.80 | stable +0.33 |

Four cycles leave three deltas once the warm-up delta is dropped, and three
points of a heap oscillating a couple of MB around its plateau satisfy both
leak shapes.

## What discriminates

Not the mean. The bundled leaky fixture — 8 KB retained per request, a leak by
construction — averages 9.6× the gate, right among the false positives. The
weakest cycle does:

| series | weakest cycle ÷ gate |
|---|---|
| `/product/[id]` — #94919 | 99× |
| leaky fixture | 9× |
| `/product-fail` — false | 2.4× |
| `/missing`, `/client-plp`, `/product-fail` (external) — false | ≤ 0.3× |

Every false positive contains a cycle that stood still or gave memory back.

## The change

A `leak` from fewer than five deltas is withdrawn to `inconclusive` unless
every one of those cycles grew by at least four times the gate. It lives in
`assessConfidence`, next to the other "does the evidence support this?"
judgements — **`classifyTrend` is untouched**, so the shapes it recognises and
its record against real leaks are unchanged. Withdrawn verdicts already write
no draft and already print the `--cycles` re-run command.

An earlier attempt used the mean at 16× the gate. The end-to-end test rejected
it by withdrawing the leaky fixture — a true positive lost to a rule aimed at
false ones. That is why the bar is per-cycle.

## Verification

Same app, same command, after the change: **nine routes, no leak verdict, no
draft**. `/client-plp` now reads:

```
? /client-plp  inconclusive  (+0.77 MB/1000 req)  heap 38.8 → 36.9 → 40.0 → 41.6 → 41.5 MB
    ⚠ judged on 3 cycles, and its weakest grew -0.11 MB against a 0.25 MB gate — on that
      few cycles ordinary oscillation reaches that, and a repeat run often disagrees
  next-leak … --routes /client-plp --cycles 8
```

The real leak is unaffected: with `abandonAfterMs` the same app reports +20 to
+43 MB/1000 req on every streaming route.

typecheck · **384 tests** · build · `pack-smoke` on the installed 0.4.0 tarball.

Also carries a test-only commit: `abandon-load.ts` was never in the Stryker
`mutate` list, so last night's rewrite of its timing shipped with no mutation
coverage. Adding it surfaced a malformed multi-header request, a connect error
that left a load phase hanging, and a lost concurrency cap — all now covered
(84.62% → 90.77%).