### PR TITLE
fix: audit hardening — keep first-pass results, honour interrupts, name control-channel failures

### DIFF
--- a/src/abandon-load.test.ts
+++ b/src/abandon-load.test.ts
@@ -189,10 +189,12 @@ describe("request shape and limits", () => {
       abandonAfterMs: 15,
     });
 
-    // One over the cap is the socket already destroyed whose `close` has not
-    // propagated to the server yet; the in-flight requests are still 4. What
-    // this guards against is the cap being ignored altogether (40 at once).
-    expect(peak).toBeLessThanOrEqual(5);
+    // Sockets the client already destroyed linger until their `close` event
+    // reaches the server, so the observed peak can exceed the cap by however
+    // many teardowns are in flight — a timing artefact, not extra concurrency.
+    // The failure this guards against is the cap being ignored altogether
+    // (all 40 at once), so the bound only needs to sit well below that.
+    expect(peak).toBeLessThan(10);
   }, 60_000);
 });
 

--- a/src/confidence.ts
+++ b/src/confidence.ts
@@ -60,6 +60,13 @@ export type ConfidenceInput = {
 };
 
 /**
+ * Cycles a re-measurement uses when a verdict came back `inconclusive` — the
+ * same figure the report's manual re-run hint prints. One definition, imported
+ * by both, so the tool can never recommend one number and use another.
+ */
+export const resolveCycles = (cycles: number): number => Math.max(cycles * 2, 6);
+
+/**
  * The verdict a route's evidence actually supports.
  *
  * `trend.verdict` stays exactly as measured — the raw record must survive — so

--- a/src/control-client.test.ts
+++ b/src/control-client.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { requestGc, requestMemory } from "./control-client.js";
+
+// The control channel's failures reach users verbatim inside route reports.
+// A bare "fetch failed" reads like a bug in this tool; the error must say
+// which channel, which operation, and what that usually means.
+describe("control channel errors", () => {
+  it("names the operation and the likely cause when nothing answers", async () => {
+    // A port nothing listens on: the same shape as a measured process that
+    // died or whose event loop is blocked mid-snapshot.
+    await expect(requestGc(1)).rejects.toThrow(/control channel \/gc on port 1/);
+    await expect(requestGc(1)).rejects.toThrow(/gone or its event loop is blocked/);
+    await expect(requestMemory(1)).rejects.toThrow(/\/mem/);
+  });
+});

--- a/src/control-client.ts
+++ b/src/control-client.ts
@@ -19,7 +19,20 @@ class ControlError extends Error {
 }
 
 async function request(port: number, pathname: string): Promise<unknown> {
-  const response = await fetch(`http://127.0.0.1:${port}${pathname}`);
+  let response: Response;
+  try {
+    response = await fetch(`http://127.0.0.1:${port}${pathname}`);
+  } catch (cause) {
+    // Bare "fetch failed" reads like a bug in this tool. Name the channel and
+    // the operation: the usual causes are the measured process dying (the
+    // ritual then surfaces its exit) or, on multi-GB heaps, a snapshot write
+    // blocking the child's event loop past the HTTP client's own timeout.
+    throw new ControlError(
+      `control channel ${pathname} on port ${port} did not answer ` +
+        `(${cause instanceof Error ? cause.message : String(cause)}) — ` +
+        `the measured process is gone or its event loop is blocked`
+    );
+  }
   if (!response.ok) {
     throw new ControlError(`control channel ${pathname} responded ${response.status}`);
   }

--- a/src/report.ts
+++ b/src/report.ts
@@ -1,7 +1,7 @@
 import type { FindingAttribution } from "./attribution.js";
 import type { HeapSample } from "./control-server.js";
 import { classifyTrend } from "./trend.js";
-import { effectiveVerdict } from "./confidence.js";
+import { effectiveVerdict, resolveCycles } from "./confidence.js";
 import { assessPeakPressure, describePeakPressure } from "./peak-pressure.js";
 import type { RouteReport, RunParameters, RunReport } from "./runner.js";
 
@@ -209,7 +209,7 @@ export function formatReport(report: RunReport): string {
   );
   if (inconclusive.length > 0) {
     const routeList = inconclusive.map((route) => route.route).join(",");
-    const moreCycles = Math.max(report.parameters.cycles * 2, 6);
+    const moreCycles = resolveCycles(report.parameters.cycles);
     lines.push(
       "",
       "hint: inconclusive means sustained sub-threshold growth — measure longer to resolve it:",

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -224,6 +224,56 @@ describe("resolving inconclusive routes", () => {
     expect(route.resolvedWithCycles).toBeUndefined();
   });
 
+  it("keeps the first pass when the second one dies", async () => {
+    // The second pass is a bonus, not a bet: a child that loses the port race
+    // twice or dies under the longer run must not turn a valid inconclusive
+    // measurement into a "failed" route.
+    const appDir = await makeAppDir({ "/page": "app/page.js" });
+    let calls = 0;
+    const report = await runMeasurement(
+      { appDir, bootstrapPath: "/fake/bootstrap.js", routeFilter: ["/"] },
+      {
+        ...makeDeps([]),
+        ritual: async (options) => {
+          calls += 1;
+          if (calls === 2) {
+            throw new Error("the measured process ran out of heap");
+          }
+          return inconclusive(options.route);
+        },
+      }
+    );
+    expect(calls).toBe(2);
+    const route = report.routes.find((entry) => entry.route === "/");
+    if (route?.status !== "measured") throw new Error("first pass should survive");
+    expect(route.trend.verdict).toBe("inconclusive");
+    expect(route.resolvedWithCycles).toBeUndefined();
+  });
+
+  it("does not start a second pass after the user interrupted", async () => {
+    const appDir = await makeAppDir({ "/page": "app/page.js" });
+    const aborter = new AbortController();
+    let calls = 0;
+    await runMeasurement(
+      {
+        appDir,
+        bootstrapPath: "/fake/bootstrap.js",
+        routeFilter: ["/"],
+        signal: aborter.signal,
+      },
+      {
+        ...makeDeps([]),
+        ritual: async (options) => {
+          calls += 1;
+          // The interrupt lands while the first pass is finishing.
+          aborter.abort();
+          return inconclusive(options.route);
+        },
+      }
+    );
+    expect(calls).toBe(1);
+  });
+
   it("reports the second pass when it is still undecided", async () => {
     const appDir = await makeAppDir({ "/page": "app/page.js" });
     const report = await runMeasurement(

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -6,6 +6,7 @@ import { attributeDiff, type AttributedDiff } from "./attribution.js";
 import {
   assessConfidence,
   effectiveVerdict,
+  resolveCycles,
   warrantsIssueDraft,
   type ConfidenceReport,
 } from "./confidence.js";
@@ -427,12 +428,6 @@ async function writeEvidenceBundle(report: RunReport, workDir: string): Promise<
   await writeFile(report.bundle.htmlReport, renderHtmlReport(report));
 }
 
-/**
- * Cycles a second pass uses — the same figure the report recommends for a
- * manual re-run, so the tool follows its own advice.
- */
-export const resolveCycles = (cycles: number): number => Math.max(cycles * 2, 6);
-
 /** Skip, measure or record the failure for one route — never throws. */
 async function routeReportFor(
   context: MeasurementContext,
@@ -459,16 +454,32 @@ async function routeReportFor(
     ) {
       return first;
     }
+    // A Ctrl+C that lands after the first pass must not start a second one:
+    // the user asked the run to stop, and an inconclusive result is still a
+    // result worth keeping.
+    if (context.options.signal?.aborted === true) {
+      return first;
+    }
     // `inconclusive` means "the evidence does not decide" and the report knows
     // exactly what would: the same route, twice the cycles. Printing that
     // command and stopping asks someone whose pods are restarting to run the
     // tool twice; going and getting the evidence is the answer they came for.
     const cycles = resolveCycles(context.options.cycles ?? RITUAL_DEFAULTS.cycles);
     progress(`re-measuring ${route.path} with ${cycles} cycles: the first pass could not call it`);
-    return await measureRoute(context, route, requestPath, index, {
-      cycles,
-      dirSuffix: "-resolve",
-    });
+    try {
+      return await measureRoute(context, route, requestPath, index, {
+        cycles,
+        dirSuffix: "-resolve",
+      });
+    } catch (cause) {
+      // The second pass is a bonus, not a bet: losing it (port race lost
+      // twice, the app dying under the longer run, an interrupt mid-pass)
+      // must not discard the valid measurement already in hand.
+      progress(
+        `re-measurement of ${route.path} failed (${cause instanceof Error ? cause.message : String(cause)}) — keeping the first pass`
+      );
+      return first;
+    }
   } catch (cause) {
     const failure = cause instanceof Error ? cause.message : String(cause);
     progress(`failed ${label}: ${failure}`);


### PR DESCRIPTION
Full audit of the tool: silent errors, error handling, flaky-test surface, testing gaps. Everything below was verified against the code or reproduced before being touched.

## Fixed here

| Finding | Class | Fix |
|---|---|---|
| A second pass that threw discarded the valid first measurement and reported the route `failed` | error handling | on any second-pass failure, keep the first result and announce why |
| Ctrl+C landing after an inconclusive first pass still started a fresh multi-minute re-measurement | interrupt handling | signal checked between passes |
| Control-channel failures surfaced as bare `fetch failed` | silent/cryptic error | error names the channel, operation, and the two real causes (process gone / event loop blocked mid-snapshot) |
| `max(cycles × 2, 6)` existed twice — runner and report hint — with nothing binding them | silent divergence risk | one definition in `confidence.ts`, imported by both |
| Socket-cap test bound one teardown-lag away from flaking on slow runners | flaky test | bounds against the real failure mode (cap ignored entirely), artefact documented |

Tests added for each fix; `control-client.ts` gets its first direct test file. **392 tests**, run three consecutive times locally hunting empirical flakiness: 3× green. Build + pack-smoke on the installed tarball.

## Audited and found sound

- All 14 silent `catch {}` blocks: each is deliberate, commented, and degrades to a documented fallback (registry → empty, config missing → `{}`, redirect probe → null, peak poll failure → stop polling, snapshot guard → typed error).
- Per-route `run.json` persistence: written after every route, so any mid-run death keeps everything measured so far.
- Warm-up is never run through the abandon path; the second pass gets its own port and work directory; `--quick --cycles N` override order is correct.
- `environment.ts` / `index.ts`: trivial capture + re-exports, covered indirectly.

## Known gaps, documented but not fixed here

- **Undici's default 300 s headers timeout is a hidden ceiling on `/snapshot`**: `writeHeapSnapshot` blocks the child's event loop, so a multi-GB heap whose snapshot takes >5 min fails the route even though the write would have finished. The new error message at least says so. A real fix means a control-channel client with no HTTP timeout (`node:http` directly) — separate change.
- **Mutation testing does not cover the orchestration layer** (`ritual.ts`, `runner.ts`, `load.ts`, `launcher.ts`, `control-server.ts`): these spawn real processes, so Stryker runs would be slow and need scoping. The verdict/report layer is covered (82–93%).
- **`bootstrap.ts` and `cli.ts` have no direct tests** — both are exercised end-to-end (launcher tests boot the real bootstrap; pack-smoke runs the real CLI), but their failure branches (control server failing to start, re-exec) are not.
- A `--cycles 100` run that lands inconclusive re-measures at 200 cycles: extreme but user-opted; the estimate mentions the second pass.