### PR TITLE
fix: own the control channel's deadlines instead of inheriting undici's

### DIFF
--- a/src/control-client.test.ts
+++ b/src/control-client.test.ts
@@ -1,15 +1,89 @@
-import { describe, expect, it } from "vitest";
-import { requestGc, requestMemory } from "./control-client.js";
+import http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { requestGc, requestMemory, requestWithDeadline } from "./control-client.js";
+
+let server: http.Server | undefined;
+
+function listen(handler: http.RequestListener): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server = http.createServer(handler);
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server?.address();
+      if (address === undefined || address === null || typeof address === "string") {
+        reject(new Error("no port"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+afterEach(async () => {
+  await new Promise<void>((resolve) => (server ? server.close(() => resolve()) : resolve()));
+  server = undefined;
+});
 
 // The control channel's failures reach users verbatim inside route reports.
 // A bare "fetch failed" reads like a bug in this tool; the error must say
 // which channel, which operation, and what that usually means.
 describe("control channel errors", () => {
   it("names the operation and the likely cause when nothing answers", async () => {
-    // A port nothing listens on: the same shape as a measured process that
-    // died or whose event loop is blocked mid-snapshot.
+    // A port nothing listens on: the same shape as a measured process that died.
     await expect(requestGc(1)).rejects.toThrow(/control channel \/gc on port 1/);
     await expect(requestGc(1)).rejects.toThrow(/gone or its event loop is blocked/);
     await expect(requestMemory(1)).rejects.toThrow(/\/mem/);
   });
+
+  it("rejects malformed JSON with the channel named", async () => {
+    const port = await listen((_req, res) => res.end("not json"));
+    await expect(requestWithDeadline(port, "/gc")).rejects.toThrow(/malformed JSON/);
+  });
+
+  it("reports non-200 answers by status", async () => {
+    const port = await listen((_req, res) => {
+      res.statusCode = 500;
+      res.end("{}");
+    });
+    await expect(requestWithDeadline(port, "/gc")).rejects.toThrow(/responded 500/);
+  });
+});
+
+// fetch rode on undici's hidden 300s header timeout — wrong in both
+// directions: it failed legitimate multi-GB snapshots at five minutes, and it
+// let a wedged child hold every poll for those same five minutes. The client
+// now owns its deadlines, so both directions are testable.
+describe("control channel deadlines", () => {
+  it("gives up on a server that accepts and never answers, naming the wait", async () => {
+    const port = await listen(() => {
+      // Accept the request, never respond: the wedged-child shape.
+    });
+    await expect(requestWithDeadline(port, "/gc", 200)).rejects.toThrow(
+      /did not answer within 0s — the measured process is wedged/
+    );
+  });
+
+  it("waits out a response slower than any hidden client timeout would allow", async () => {
+    // Scaled-down proof that the deadline is ours: the response arrives after
+    // a delay, and only our own bound decides whether that is too late.
+    const port = await listen((_req, res) => {
+      setTimeout(() => {
+        res.end(JSON.stringify({ ok: true }));
+      }, 300).unref();
+    });
+    await expect(requestWithDeadline(port, "/snapshot?name=x", 5000)).resolves.toEqual({
+      ok: true,
+    });
+  });
+
+  it("a slow trickle is judged by wall clock, not by idle time between bytes", async () => {
+    const port = await listen((_req, res) => {
+      res.write("{");
+      // Keeps the socket busy forever, a few bytes at a time. An idle-based
+      // timeout would reset on every chunk and never fire.
+      const trickle = setInterval(() => res.write(" "), 50);
+      trickle.unref();
+    });
+    await expect(requestWithDeadline(port, "/mem", 300)).rejects.toThrow(/within 0s/);
+  }, 10_000);
 });

--- a/src/control-client.ts
+++ b/src/control-client.ts
@@ -1,3 +1,4 @@
+import http from "node:http";
 import { z } from "zod";
 import type { HeapSample } from "./control-server.js";
 
@@ -18,25 +19,110 @@ class ControlError extends Error {
   }
 }
 
-async function request(port: number, pathname: string): Promise<unknown> {
-  let response: Response;
-  try {
-    response = await fetch(`http://127.0.0.1:${port}${pathname}`);
-  } catch (cause) {
-    // Bare "fetch failed" reads like a bug in this tool. Name the channel and
-    // the operation: the usual causes are the measured process dying (the
-    // ritual then surfaces its exit) or, on multi-GB heaps, a snapshot write
-    // blocking the child's event loop past the HTTP client's own timeout.
-    throw new ControlError(
-      `control channel ${pathname} on port ${port} did not answer ` +
-        `(${cause instanceof Error ? cause.message : String(cause)}) — ` +
-        `the measured process is gone or its event loop is blocked`
+/**
+ * How long each operation may take, wall-clock — owned here instead of
+ * inherited from an HTTP client.
+ *
+ * `fetch` rode on undici's implicit 300 s header timeout, which sat in
+ * exactly the wrong place: `v8.writeHeapSnapshot` blocks the child's event
+ * loop until the file is on disk, so a multi-GB snapshot that needed more
+ * than five minutes failed the route after doing exactly what it was asked.
+ * Each bound below is roughly an order of magnitude past the worst case
+ * measured in validation (2.9 GB snapshots finished in under five minutes;
+ * three GC passes on 3 GB heaps in seconds). The snapshot bound exists so a
+ * wedged child cannot hang an unattended run forever, not to police big heaps.
+ */
+const DEADLINES_MS: Record<string, number> = {
+  "/mem": 30_000,
+  "/gc": 180_000,
+  "/snapshot": 1_800_000,
+};
+const DEFAULT_DEADLINE_MS = 30_000;
+
+function deadlineFor(pathname: string): number {
+  const operation = pathname.split("?")[0] ?? pathname;
+  return DEADLINES_MS[operation] ?? DEFAULT_DEADLINE_MS;
+}
+
+/**
+ * One loopback GET with this tool's own deadline and nothing else's.
+ *
+ * `socket.setTimeout` alone is not enough: it fires on idle and a
+ * slow-trickling response resets it, while a run's patience is wall-clock.
+ * A plain timer plus `request.destroy()` measures the only thing that
+ * matters — how long the caller has been waiting.
+ */
+function get(
+  port: number,
+  pathname: string,
+  deadlineMs: number
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const settle = (outcome: { ok: { status: number; body: string } } | { error: Error }): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      if ("ok" in outcome) {
+        resolve(outcome.ok);
+      } else {
+        reject(outcome.error);
+      }
+    };
+    const request = http.get({ host: "127.0.0.1", port, path: pathname }, (response) => {
+      const chunks: Buffer[] = [];
+      response.on("data", (chunk: Buffer) => chunks.push(chunk));
+      response.once("end", () =>
+        settle({
+          ok: { status: response.statusCode ?? 0, body: Buffer.concat(chunks).toString("utf8") },
+        })
+      );
+    });
+    // The timer rejects directly instead of waiting for a destroy-triggered
+    // error event: destroying a request whose response already started does
+    // not reliably emit one, and a deadline that only sometimes fires is no
+    // deadline at all.
+    const timer = setTimeout(() => {
+      settle({
+        error: new ControlError(
+          `control channel ${pathname} on port ${port} did not answer within ` +
+            `${Math.round(deadlineMs / 1000)}s — the measured process is wedged, or this ` +
+            `snapshot is larger than anything this tool has been validated on`
+        ),
+      });
+      request.destroy();
+    }, deadlineMs);
+    timer.unref();
+    // Bare "fetch failed" read like a bug in this tool. Name the channel
+    // and the operation: the usual cause is the measured process dying,
+    // which the ritual then surfaces via its exit.
+    request.once("error", (cause) =>
+      settle({
+        error: new ControlError(
+          `control channel ${pathname} on port ${port} did not answer ` +
+            `(${cause.message}) — the measured process is gone or its event loop is blocked`
+        ),
+      })
     );
-  }
-  if (!response.ok) {
+  });
+}
+
+async function request(
+  port: number,
+  pathname: string,
+  deadlineMs = deadlineFor(pathname)
+): Promise<unknown> {
+  const response = await get(port, pathname, deadlineMs);
+  if (response.status !== 200) {
     throw new ControlError(`control channel ${pathname} responded ${response.status}`);
   }
-  return response.json();
+  try {
+    return JSON.parse(response.body) as unknown;
+  } catch {
+    throw new ControlError(`control channel ${pathname} answered with malformed JSON`);
+  }
 }
 
 /** Forces GC in the measured process and returns a settled memory sample. */
@@ -73,3 +159,6 @@ export async function requestSnapshot(
   }
   return parsed;
 }
+
+/** Test seam: the production deadlines would make a hung-server test take minutes. */
+export const requestWithDeadline = request;


### PR DESCRIPTION
Closes the most serious of the three gaps documented in #33.

## The problem

The control channel used `fetch`, which rides on undici's implicit **300 s header timeout**. That hidden ceiling sat in exactly the wrong place, and failed in both directions:

- `v8.writeHeapSnapshot` blocks the child's event loop until the file is on disk. A multi-GB heap whose snapshot takes >5 min **failed the route after doing exactly what it was asked**. Our 2.9 GB snapshots on the #92287 repro finished inside the limit; the 4.3 GB production heaps that issue reports would be a coin toss.
- A child that is alive but wedged held `/mem` and `/gc` polls for those same five silent minutes each — a stuck route turned into a near-hung run.

## The fix

`node:http` directly, with per-operation deadlines owned by this tool:

| op | deadline | worst case measured |
|---|---|---|
| `/mem` | 30 s | milliseconds |
| `/gc` | 3 min | seconds on 3 GB heaps |
| `/snapshot` | 30 min | under 5 min at 2.9 GB |

Each bound is roughly an order of magnitude past the worst case seen in validation. The snapshot bound exists so a wedged child cannot hang an unattended run forever — not to police big heaps, and the timeout error says exactly that.

Two implementation details that matter:

- The deadline **rejects from the timer itself**: destroying a request whose response already started does not reliably emit an error event, and a deadline that only sometimes fires is no deadline at all.
- `socket.setTimeout` was not an option: it fires on idle and a slow-trickling response resets it — wall-clock is what a run's patience is made of. There is a test where the server trickles bytes forever and the deadline still fires.

No user-facing flag: a knob for "how long may a wedged process hang the run" helps nobody.

## Verification

Suite ×3 (**397 tests**, hunting flakiness empirically: 3× green) · typecheck · build · `pack-smoke` on the installed 0.4.2 tarball. New tests cover: never-answers, slower-than-any-hidden-timeout, infinite trickle, malformed JSON, non-200, connection refused.