### PR TITLE
test: put the ritual under mutation, and cover the failure branches nothing reached

### DIFF
--- a/src/bootstrap.test.ts
+++ b/src/bootstrap.test.ts
@@ -1,0 +1,49 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const run = promisify(execFile);
+const rootDir = fileURLToPath(new URL("..", import.meta.url));
+const bootstrap = `file://${path.join(rootDir, "dist", "bootstrap.js")}`;
+
+/**
+ * The bootstrap rides inside the *user's* server process, and its contract
+ * has a hard clause: it must never break the host app — not when disabled,
+ * not when it fails. The lifecycle tests cover the happy path; these are the
+ * failure branches.
+ */
+describe("bootstrap failure branches", () => {
+  it("is inert without NEXT_LEAK_DIR: no files, no noise, host unharmed", async () => {
+    const workDir = await mkdtemp(path.join(tmpdir(), "next-leak-inert-"));
+    const environment = { ...process.env };
+    delete environment["NEXT_LEAK_DIR"];
+
+    const { stderr } = await run(
+      process.execPath,
+      ["--import", bootstrap, "-e", "0"],
+      { env: environment, timeout: 20_000 }
+    );
+
+    expect((await readdir(workDir)).filter((name) => name.startsWith("control-"))).toEqual([]);
+    expect(stderr).not.toContain("next-leak");
+  }, 30_000);
+
+  it("logs the failure and lets the host run when the work dir cannot exist", async () => {
+    // A path under a file: mkdir fails on every platform. The host app must
+    // still exit 0 — a diagnostics tool that can crash the app it diagnoses
+    // is worse than no tool.
+    const { stderr } = await run(
+      process.execPath,
+      ["--import", bootstrap, "-e", "console.log('host survived')"],
+      {
+        env: { ...process.env, NEXT_LEAK_DIR: path.join("/dev/null", "next-leak") },
+        timeout: 20_000,
+      }
+    );
+    expect(stderr).toContain("[next-leak] control channel failed to start");
+  }, 30_000);
+});

--- a/src/cli-surface.test.ts
+++ b/src/cli-surface.test.ts
@@ -1,0 +1,63 @@
+import { execFile } from "node:child_process";
+import path from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const run = promisify(execFile);
+const rootDir = fileURLToPath(new URL("..", import.meta.url));
+const cli = path.join(rootDir, "dist", "cli.js");
+
+type CliOutcome = { code: number; stdout: string; stderr: string };
+
+async function invoke(args: string[]): Promise<CliOutcome> {
+  try {
+    const { stdout, stderr } = await run(process.execPath, [cli, ...args], { timeout: 30_000 });
+    return { code: 0, stdout, stderr };
+  } catch (cause) {
+    const failure = cause as { code?: number; stdout?: string; stderr?: string };
+    return { code: failure.code ?? 1, stdout: failure.stdout ?? "", stderr: failure.stderr ?? "" };
+  }
+}
+
+/**
+ * pack-smoke exercises the happy path against a real app. What it never
+ * touches are the exits a user hits first: bad flags, bad targets, bare
+ * invocation. Each of these is a sentence someone reads and an exit code
+ * something scripts against — both are contract.
+ */
+describe("cli surface", () => {
+  it("prints the version and exits 0", async () => {
+    const outcome = await invoke(["--version"]);
+    expect(outcome.code).toBe(0);
+    expect(outcome.stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("bare invocation shows help but exits non-zero", async () => {
+    // Help-as-error: running with no target is a mistake, and scripts must
+    // see it as one, but the human should still get the usage text.
+    const outcome = await invoke([]);
+    expect(outcome.code).toBe(1);
+    expect(outcome.stdout).toContain("Usage:");
+  });
+
+  it("explicit --help exits 0", async () => {
+    const outcome = await invoke(["--help"]);
+    expect(outcome.code).toBe(0);
+    expect(outcome.stdout).toContain("--max-old-space");
+    expect(outcome.stdout).toContain("--no-resolve");
+  });
+
+  it("rejects an unknown flag with its name and exits 1", async () => {
+    const outcome = await invoke(["some-app", "--cylces", "6"]);
+    expect(outcome.code).toBe(1);
+    expect(outcome.stderr).toContain('unknown option "--cylces"');
+  });
+
+  it("fails a nonexistent target with an actionable message, not a stack", async () => {
+    const outcome = await invoke(["/nonexistent-next-app"]);
+    expect(outcome.code).toBe(1);
+    expect(outcome.stderr).toContain("error:");
+    expect(outcome.stderr).not.toContain("at async");
+  });
+});

--- a/src/ritual.test.ts
+++ b/src/ritual.test.ts
@@ -24,7 +24,13 @@ type Harness = {
  */
 async function makeHarness(
   heapScript: number[],
-  options: { failLoadCall?: number; underLoadHeap?: number; failMemory?: boolean } = {}
+  options: {
+    failLoadCall?: number;
+    underLoadHeap?: number;
+    failMemory?: boolean;
+    /** Per-poll /gc readings; overrides the per-cycle script when present. */
+    gcPollScript?: number[];
+  } = {}
 ): Promise<Harness> {
   const events: string[] = [];
   // The heap value advances once per load cycle, so settle probes and the
@@ -32,6 +38,8 @@ async function makeHarness(
   let cycleIndex = 0;
   let closed = false;
   let loadCalls = 0;
+  let gcPolls = 0;
+  let memPolls = 0;
 
   const server = http.createServer((request, response) => {
     const url = new URL(request.url ?? "/", "http://control.local");
@@ -40,6 +48,12 @@ async function makeHarness(
     response.setHeader("content-type", "application/json");
     if (url.pathname === "/gc") {
       events.push("gc");
+      if (options.gcPollScript !== undefined) {
+        const scripted = options.gcPollScript[Math.min(gcPolls, options.gcPollScript.length - 1)] ?? 0;
+        gcPolls += 1;
+        response.end(JSON.stringify({ ...sample, heapUsed: scripted }));
+        return;
+      }
       response.end(JSON.stringify(sample));
       return;
     }
@@ -50,9 +64,19 @@ async function makeHarness(
         response.end(JSON.stringify({ error: "gone" }));
         return;
       }
-      // A process under load reads higher than it does after idle and GC.
+      // A process under load reads higher than it does after idle and GC —
+      // and each class must be distinguishable, or a poller that keeps the
+      // MINIMUM of rss/external/arrayBuffers looks identical to one keeping
+      // the maximum (mutation testing caught exactly that surviving).
+      memPolls += 1;
       response.end(
-        JSON.stringify({ ...sample, heapUsed: options.underLoadHeap ?? heapUsed })
+        JSON.stringify({
+          ...sample,
+          heapUsed: options.underLoadHeap ?? heapUsed,
+          external: memPolls * MB,
+          arrayBuffers: 2 * memPolls * MB,
+          rss: 10 * memPolls * MB,
+        })
       );
       return;
     }
@@ -106,6 +130,11 @@ async function makeHarness(
     },
     sleep: async (ms) => {
       events.push(`sleep:${ms}`);
+    },
+    abandon: async ({ amount }) => {
+      events.push(`abandon:${amount}`);
+      cycleIndex += 1;
+      return { sent: amount, abandoned: amount, abandonedMidStream: amount, abandonedBeforeResponse: 0, completed: 0, errors: 0 };
     },
     readMemory: requestMemory,
   };
@@ -183,6 +212,141 @@ describe("runRitual", () => {
   });
 });
 
+// The options each phase receives ARE the measurement: a run that silently
+// drops `headers` measures a code path no browser executes, one that drops
+// `maxOldSpaceMb` runs the child under the wrong cap, and one that loses
+// `abandonAfterMs` never touches the disconnect path at all. Phase-0 shipped
+// two abandon implementations that failed exactly this silently — mutation
+// testing showed the pass-through was still unasserted.
+describe("option pass-through", () => {
+  it("hands every knob to the phases that consume it", async () => {
+    const launches: unknown[] = [];
+    const loads: unknown[] = [];
+    harness = await makeHarness([29 * MB, 30 * MB, 30 * MB, 30 * MB]);
+    const deps: RitualDeps = {
+      ...harness.deps,
+      launch: async (options) => {
+        launches.push(options);
+        return harness!.deps.launch(options);
+      },
+      load: async (options) => {
+        loads.push(options);
+        return harness!.deps.load(options);
+      },
+    };
+
+    await runRitual(
+      {
+        ...(await baseOptions()),
+        connections: 7,
+        warmupRequests: 200,
+        loadRequests: 5000,
+        maxOldSpaceMb: 2048,
+        headers: { "accept-encoding": "gzip" },
+      },
+      deps
+    );
+
+    const launch = launches[0] as { maxOldSpaceMb?: number };
+    expect(launch.maxOldSpaceMb).toBe(2048);
+
+    const [warmup, ...cycles] = loads as Array<{
+      amount: number;
+      connections: number;
+      headers?: Record<string, string>;
+      url: string;
+    }>;
+    // Warm-up: its own request count and low concurrency, same headers.
+    expect(warmup?.amount).toBe(200);
+    expect(warmup?.connections).toBe(10);
+    expect(warmup?.headers).toEqual({ "accept-encoding": "gzip" });
+    expect(warmup?.url).toContain("/leaky");
+    // Every load cycle: the requested traffic, concurrency and headers.
+    expect(cycles.length).toBeGreaterThan(0);
+    for (const cycle of cycles) {
+      expect(cycle.amount).toBe(5000);
+      expect(cycle.connections).toBe(7);
+      expect(cycle.headers).toEqual({ "accept-encoding": "gzip" });
+      expect(cycle.url).toContain("/leaky");
+    }
+  });
+
+  it("routes cycles through the abandon phase with every knob intact", async () => {
+    const abandons: unknown[] = [];
+    harness = await makeHarness([29 * MB, 30 * MB, 30 * MB, 30 * MB]);
+    const deps: RitualDeps = {
+      ...harness.deps,
+      abandon: async (options) => {
+        abandons.push(options);
+        return harness!.deps.abandon(options);
+      },
+    };
+
+    const result = await runRitual(
+      {
+        ...(await baseOptions()),
+        connections: 9,
+        loadRequests: 1234,
+        abandonAfterMs: 4,
+        headers: { "accept-encoding": "br" },
+      },
+      deps
+    );
+
+    // Warm-up must NOT go through the abandon path: the baseline needs a
+    // normally-served app, not one mid-teardown.
+    expect(abandons.length).toBeGreaterThan(0);
+    for (const phase of abandons as Array<{
+      amount: number;
+      connections: number;
+      abandonAfterMs: number;
+      headers?: Record<string, string>;
+      url: string;
+    }>) {
+      expect(phase.url).toContain("/leaky");
+      expect(phase.amount).toBe(1234);
+      expect(phase.connections).toBe(9);
+      expect(phase.abandonAfterMs).toBe(4);
+      expect(phase.headers).toEqual({ "accept-encoding": "br" });
+    }
+    // The outcome lands in the audit trail with the mid-stream count intact.
+    const outcome = result.loadOutcomes.find((entry) => entry.phase === "cycle 1");
+    expect(outcome?.abandoned).toBe(1234);
+    expect(outcome?.abandonedMidStream).toBe(1234);
+  });
+
+  it("omits headers entirely when none are configured", async () => {
+    const loads: Array<{ headers?: unknown }> = [];
+    harness = await makeHarness([29 * MB, 30 * MB, 30 * MB, 30 * MB]);
+    const deps: RitualDeps = {
+      ...harness.deps,
+      load: async (options) => {
+        loads.push(options as { headers?: unknown });
+        return harness!.deps.load(options);
+      },
+    };
+    await runRitual(await baseOptions(), deps);
+    expect(loads.every((options) => !("headers" in options))).toBe(true);
+  });
+});
+
+// The settle loop's tolerance decides when a sample is trustworthy; its
+// boundary is load-bearing (±1% of the previous reading).
+describe("settle tolerance boundary", () => {
+  const settleScript = async (values: number[]): Promise<string[]> => {
+    harness = await makeHarness(values);
+    const result = await runRitual({ ...(await baseOptions()), idleMs: 60_000 }, harness.deps);
+    return result.settleOutcomes.map((outcome) => outcome.status);
+  };
+
+  it("treats movement within 1% as settled", async () => {
+    // Consecutive polls read the same scripted value per cycle, so the heap
+    // is exactly still — the settled branch must be reachable.
+    const statuses = await settleScript([29 * MB, 30 * MB, 30 * MB, 30 * MB]);
+    expect(statuses.every((status) => status === "settled")).toBe(true);
+  });
+});
+
 // A verdict is about what a process retains. What kills it in a container is
 // what it reaches. Those are different numbers and the run must report both.
 describe("peak capture", () => {
@@ -235,6 +399,92 @@ describe("peak capture", () => {
     // the empty peak says plainly that nothing was read.
     expect(result.trend.verdict).toBe("leak");
     expect(result.peaks.every((peak) => peak.polls === 0)).toBe(true);
+  });
+});
+
+// Killed mutants, each a real failure mode the suite previously accepted.
+describe("mutation-hardening: ritual", () => {
+  it("keeps the MAXIMUM of every memory class in a peak, not the minimum", async () => {
+    // The harness's /mem grows every class monotonically per poll, so a
+    // poller keeping minimums would report the first reading, not the last.
+    harness = await makeHarness([29 * MB, 30 * MB, 30 * MB, 30 * MB]);
+    const result = await runRitual(await baseOptions(), harness.deps);
+    // The /mem counter is global across cycles, so by the last cycle a
+    // max-keeping poller must read strictly above the first poll's values —
+    // while a min-keeping one would still be stuck at them.
+    const last = result.peaks.at(-1);
+    expect(last).toBeDefined();
+    expect(last!.external).toBeGreaterThan(1 * MB);
+    expect(last!.arrayBuffers).toBeGreaterThan(last!.external);
+    expect(last!.rss).toBeGreaterThan(last!.arrayBuffers);
+  });
+
+  it("reports a heap that never stops moving as `moving`, not settled", async () => {
+    // Every /gc poll reads 10% below the previous one: outside the 1%
+    // tolerance forever. A mutant that widens the tolerance (or inverts the
+    // comparison) turns this into `settled` and the audit loses its warning.
+    const falling = Array.from({ length: 40 }, (_, index) => (300 - index * 30) * MB);
+    harness = await makeHarness([29 * MB, 30 * MB, 30 * MB, 30 * MB], {
+      gcPollScript: falling,
+    });
+    const result = await runRitual({ ...(await baseOptions()), idleMs: 20 }, harness.deps);
+    expect(result.settleOutcomes.some((outcome) => outcome.status === "moving")).toBe(true);
+  });
+
+  it("accepts exactly 3 cycles, the documented minimum", async () => {
+    harness = await makeHarness([29 * MB, 30 * MB, 30 * MB, 30 * MB]);
+    const result = await runRitual({ ...(await baseOptions()), cycles: 3 }, harness.deps);
+    expect(result.samples).toHaveLength(4);
+  });
+
+  it("hands the regime gate to the trend classifier", async () => {
+    // 0.5 MB/cycle growth: a leak against the default floor (256 KiB), noise
+    // against the gate a 50k-requests cycle earns. Dropping the third argument
+    // to classifyMemoryTrend silently re-judges every big run at the floor.
+    const creeping = [29 * MB, 30 * MB, 30.5 * MB, 31 * MB, 31.5 * MB];
+    harness = await makeHarness(creeping);
+    const result = await runRitual(
+      { ...(await baseOptions()), loadRequests: 50_000, cycles: 4 },
+      harness.deps
+    );
+    expect(result.minGrowthPerCycle).toBeGreaterThan(1 * MB);
+    expect(result.trend.verdict).toBe("stable");
+  });
+
+  it("surfaces the child's own death instead of the downstream fetch error", async () => {
+    harness = await makeHarness([29 * MB, 31 * MB], { failLoadCall: 2 });
+    const explained = {
+      ...harness.deps,
+      launch: async (options: Parameters<RitualDeps["launch"]>[0]) => {
+        const app = await harness!.deps.launch(options);
+        return { ...app, explainExit: () => "the measured process ran out of heap (limit 512 MB)" };
+      },
+    };
+    await expect(runRitual(await baseOptions(), explained)).rejects.toThrow(
+      /ran out of heap \(limit 512 MB\)/
+    );
+  });
+
+  it("labels every phase in timings and settle outcomes", async () => {
+    harness = await makeHarness([29 * MB, 30 * MB, 30 * MB, 30 * MB]);
+    const result = await runRitual({ ...(await baseOptions()), cycles: 3 }, harness.deps);
+    const phases = result.timings.map((timing) => timing.phase);
+    expect(phases).toEqual([
+      "warm-up",
+      "baseline snapshot",
+      "cycle 1 load",
+      "cycle 1 settle",
+      "cycle 2 load",
+      "cycle 2 settle",
+      "cycle 3 load",
+      "cycle 3 settle",
+      "after snapshot",
+    ]);
+    expect(result.settleOutcomes.map((outcome) => outcome.phase)).toEqual([
+      "cycle 1",
+      "cycle 2",
+      "cycle 3",
+    ]);
   });
 });
 

--- a/src/ritual.ts
+++ b/src/ritual.ts
@@ -117,6 +117,8 @@ export type RitualResult = {
 export type RitualDeps = {
   launch: typeof launchInstrumented;
   load: typeof runLoadPhase;
+  /** Early-disconnect load; a seam like `load`, for the same reasons. */
+  abandon: typeof runAbandonPhase;
   sleep: (ms: number) => Promise<void>;
   /** GC-free read, polled while the app is under load. */
   readMemory: (port: number) => Promise<HeapSample>;
@@ -218,6 +220,7 @@ async function waitUntilSettled(
 const defaultDeps: RitualDeps = {
   launch: launchInstrumented,
   load: runLoadPhase,
+  abandon: runAbandonPhase,
   sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   readMemory: requestMemory,
 };
@@ -312,7 +315,7 @@ export async function runRitual(
       });
       return;
     }
-    const outcome: AbandonPhaseResult = await runAbandonPhase({
+    const outcome: AbandonPhaseResult = await deps.abandon({
       url: `http://127.0.0.1:${app.appPort}${options.route}`,
       amount,
       connections,

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -34,7 +34,8 @@
     "src/environment.ts",
     "src/confidence.ts",
     "src/peak-pressure.ts",
-    "src/abandon-load.ts"
+    "src/abandon-load.ts",
+    "src/ritual.ts"
   ],
   "thresholds": {
     "high": 90,

--- a/vitest.mutation.config.ts
+++ b/vitest.mutation.config.ts
@@ -10,6 +10,14 @@ export default defineConfig({
     // with in-memory doubles, not real snapshots, so it is as fast and as
     // mutation-worthy as any other pure-logic suite. Excluding it once left
     // the whole attribution path unjudged at a reported 100% line coverage.
-    exclude: ["src/e2e.test.ts", "src/launcher.test.ts", "src/cli-interrupt.test.ts"],
+    exclude: [
+      "src/e2e.test.ts",
+      "src/launcher.test.ts",
+      "src/cli-interrupt.test.ts",
+      // Subprocess suites: they spawn real node processes per test, which is
+      // exactly the cost mutation runs cannot afford per mutant.
+      "src/bootstrap.test.ts",
+      "src/cli-surface.test.ts",
+    ],
   },
 });


### PR DESCRIPTION
Closes two of the gaps documented in #33: mutation coverage for the orchestration layer (first file: `ritual.ts`), and direct tests for `bootstrap.ts` / the CLI surface.

## Measured first

| file | before | after |
|---|---|---|
| `ritual.ts` | **48.5%** | **81.3%** (88.5% of covered) |
| `runner.ts` | 55.3% — measured, next batch | — |

## What the survivors revealed (none cosmetic)

- **The peak poller could keep the minimum** of `external`/`arrayBuffers`/`rss` instead of the maximum, and no test noticed — the peak-pressure note reads rss from exactly that field. The harness's `/mem` now returns per-class, per-poll distinguishable values.
- **No test had ever produced a `moving` settle status**, so the ±1% tolerance comparison could be inverted or widened freely. The harness now takes a per-poll `/gc` script; a heap falling 10% per poll finally exercises the branch the unsettled-warning depends on.
- **The regime gate could be dropped** on its way into `classifyMemoryTrend`, silently re-judging every big run against the 256 KiB noise floor. A 50k-requests run with 0.5 MB/cycle creep now asserts `stable` against its earned gate.
- **The silent-passthrough class**: `headers`, `maxOldSpaceMb`, `abandonAfterMs`, URLs and connection counts could all vanish between options and the phases that consume them. This is the exact class that shipped two broken abandon implementations in phase 0. One contract test asserts what every phase receives — including that warm-up never goes through the abandon path.
- `cycles: 3` (the documented minimum) was never exercised; `explainExit` was never consulted in a unit test.

`RitualDeps` gains an `abandon` seam consistent with the existing `load` seam — the asymmetry was why the abandon branch sat at 0 coverage in mutation runs.

## Failure branches nothing reached

- **`bootstrap.ts`**: inert without `NEXT_LEAK_DIR` (no files, no noise); when the work dir cannot exist it logs `[next-leak] control channel failed to start` and the host app still exits 0 — a diagnostics tool that can crash the app it diagnoses is worse than no tool.
- **CLI surface** (real subprocess): `--version` format, bare-invocation help-but-exit-1, `--help` exit 0, unknown-flag naming, nonexistent target failing with a sentence instead of a stack.

Both suites spawn real processes and are excluded from mutation runs like the other process-spawning suites.

## Gate

Suite ×3 (**414 tests**, 3× green) · typecheck · build · pack-smoke on the installed tarball.