### PR TITLE
test: put the process-boundary modules under mutation

### DIFF
--- a/src/control-client.test.ts
+++ b/src/control-client.test.ts
@@ -1,6 +1,12 @@
 import http from "node:http";
 import { afterEach, describe, expect, it } from "vitest";
-import { requestGc, requestMemory, requestWithDeadline } from "./control-client.js";
+import {
+  deadlineForOperation,
+  requestGc,
+  requestMemory,
+  requestSnapshot,
+  requestWithDeadline,
+} from "./control-client.js";
 
 let server: http.Server | undefined;
 
@@ -35,6 +41,27 @@ describe("control channel errors", () => {
     await expect(requestMemory(1)).rejects.toThrow(/\/mem/);
   });
 
+  it("is a named error type, so reports can distinguish it from app failures", async () => {
+    const failure = await requestGc(1).catch((cause: Error) => cause);
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).name).toBe("ControlError");
+  });
+
+  it("refuses samples from a process running without --expose-gc", async () => {
+    // Such samples are not settled: reporting them as post-GC numbers would
+    // be the classic false measurement the ritual exists to prevent.
+    const sample = { gcExposed: false, heapUsed: 1, rss: 1, external: 0, arrayBuffers: 0 };
+    const port = await listen((req, res) => {
+      if (req.url?.startsWith("/snapshot")) {
+        res.end(JSON.stringify({ file: "/x.heapsnapshot", sample }));
+        return;
+      }
+      res.end(JSON.stringify(sample));
+    });
+    await expect(requestGc(port)).rejects.toThrow(/without --expose-gc/);
+    await expect(requestSnapshot(port, "after")).rejects.toThrow(/without --expose-gc/);
+  });
+
   it("rejects malformed JSON with the channel named", async () => {
     const port = await listen((_req, res) => res.end("not json"));
     await expect(requestWithDeadline(port, "/gc")).rejects.toThrow(/malformed JSON/);
@@ -54,12 +81,21 @@ describe("control channel errors", () => {
 // let a wedged child hold every poll for those same five minutes. The client
 // now owns its deadlines, so both directions are testable.
 describe("control channel deadlines", () => {
+  it("maps every operation to its own bound, query string included", () => {
+    // `/snapshot?name=x` falling back to the 30s default would reinstate the
+    // hidden snapshot ceiling this client exists to remove.
+    expect(deadlineForOperation("/snapshot?name=after")).toBe(1_800_000);
+    expect(deadlineForOperation("/gc")).toBe(180_000);
+    expect(deadlineForOperation("/mem")).toBe(30_000);
+    expect(deadlineForOperation("/anything-else")).toBe(30_000);
+  });
+
   it("gives up on a server that accepts and never answers, naming the wait", async () => {
     const port = await listen(() => {
       // Accept the request, never respond: the wedged-child shape.
     });
     await expect(requestWithDeadline(port, "/gc", 200)).rejects.toThrow(
-      /did not answer within 0s — the measured process is wedged/
+      /did not answer within 0s — the measured process is wedged, or this snapshot is larger than anything this tool has been validated on/
     );
   });
 

--- a/src/control-client.ts
+++ b/src/control-client.ts
@@ -162,3 +162,11 @@ export async function requestSnapshot(
 
 /** Test seam: the production deadlines would make a hung-server test take minutes. */
 export const requestWithDeadline = request;
+
+/**
+ * Test seam for the deadline table itself. A mutation run showed the mapping
+ * could quietly send `/snapshot?name=x` to the 30-second default instead of
+ * its 30-minute bound — reinstating, from the inside, the exact ceiling this
+ * client exists to remove.
+ */
+export const deadlineForOperation = deadlineFor;

--- a/src/control-lifecycle.test.ts
+++ b/src/control-lifecycle.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+// Process-spawning suite, split from control-server.test.ts so mutation runs
+// (which sandbox the repo without dist/) never execute it — the same policy
+// as bootstrap.test.ts and cli-surface.test.ts.
+describe("control server lifecycle", () => {
+  it("does not keep the host process alive", async () => {
+    // Found while probing Node 24.4: an open control socket kept the measured
+    // process running forever. Measuring must not change what is measured.
+    const { execFileSync } = await import("node:child_process");
+    const { fileURLToPath } = await import("node:url");
+    const pathModule = await import("node:path");
+    const { mkdtemp } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+
+    const rootDir = fileURLToPath(new URL("..", import.meta.url));
+    const workDir = await mkdtemp(pathModule.join(tmpdir(), "next-leak-unref-"));
+    const started = Date.now();
+    execFileSync(
+      process.execPath,
+      ["--import", `file://${pathModule.join(rootDir, "dist", "bootstrap.js")}`, "-e", "0"],
+      { env: { ...process.env, NEXT_LEAK_DIR: workDir }, timeout: 20_000 }
+    );
+    // Without unref() this never returns.
+    expect(Date.now() - started).toBeLessThan(15_000);
+  }, 30_000);
+
+  it("announces one control file per process id", async () => {
+    const { readdir, mkdtemp } = await import("node:fs/promises");
+    const { execFileSync } = await import("node:child_process");
+    const { fileURLToPath } = await import("node:url");
+    const pathModule = await import("node:path");
+    const { tmpdir } = await import("node:os");
+
+    const rootDir = fileURLToPath(new URL("..", import.meta.url));
+    const workDir = await mkdtemp(pathModule.join(tmpdir(), "next-leak-pids-"));
+    const bootstrap = `file://${pathModule.join(rootDir, "dist", "bootstrap.js")}`;
+    for (let i = 0; i < 2; i += 1) {
+      execFileSync(process.execPath, ["--import", bootstrap, "-e", "0"], {
+        env: { ...process.env, NEXT_LEAK_DIR: workDir },
+        timeout: 20_000,
+      });
+    }
+    const files = (await readdir(workDir)).filter((name) => name.startsWith("control-"));
+    // Two processes → two announcements, no overwriting.
+    expect(files).toHaveLength(2);
+  }, 40_000);
+});

--- a/src/control-server.test.ts
+++ b/src/control-server.test.ts
@@ -10,9 +10,29 @@ afterEach(async () => {
 
 describe("forceGc", () => {
   it("reports whether GC is exposed instead of throwing", async () => {
-    // Vitest does not run with --expose-gc by default; either outcome is
-    // valid, but it must never throw.
-    await expect(forceGc()).resolves.toBeTypeOf("boolean");
+    // Vitest does not run with --expose-gc, so the honest answer here is
+    // exactly `false` — a hardcoded `true` would claim samples are settled
+    // when nothing was ever collected.
+    await expect(forceGc()).resolves.toBe(false);
+  });
+
+  it("runs exactly the requested passes when GC is exposed", async () => {
+    const g = globalThis as typeof globalThis & { gc?: () => void };
+    const original = g.gc;
+    const collect = vi.fn();
+    g.gc = collect;
+    try {
+      await expect(forceGc()).resolves.toBe(true);
+      // Three passes are the validated protocol; a fourth would silently
+      // change every post-GC sample's regime.
+      expect(collect).toHaveBeenCalledTimes(3);
+    } finally {
+      if (original === undefined) {
+        delete g.gc;
+      } else {
+        g.gc = original;
+      }
+    }
   });
 });
 
@@ -21,10 +41,12 @@ describe("startControlServer", () => {
     server = await startControlServer({ snapshotDir: "/unused" });
     const response = await fetch(`http://127.0.0.1:${server.port}/gc`);
     expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
     const body = (await response.json()) as Record<string, unknown>;
     expect(body["heapUsed"]).toBeTypeOf("number");
     expect(body["rss"]).toBeTypeOf("number");
-    expect(body["gcExposed"]).toBeTypeOf("boolean");
+    // No --expose-gc in vitest: the flag must say so, not guess.
+    expect(body["gcExposed"]).toBe(false);
   });
 
   it("samples on /mem without collecting", async () => {
@@ -41,6 +63,9 @@ describe("startControlServer", () => {
       const body = (await response.json()) as Record<string, unknown>;
       expect(body["heapUsed"]).toBeTypeOf("number");
       expect(body["arrayBuffers"]).toBeTypeOf("number");
+      // With a gc function installed the flag must reflect it — the ritual
+      // rejects processes whose samples would be meaningless.
+      expect(body["gcExposed"]).toBe(true);
       expect(collect).not.toHaveBeenCalled();
 
       await fetch(`http://127.0.0.1:${server.port}/gc`);
@@ -83,59 +108,19 @@ describe("startControlServer", () => {
     expect(written).toEqual(["/snapshots/evil.heapsnapshot"]);
   });
 
-  it("rejects snapshot requests without a name", async () => {
+  it("rejects snapshot requests without a name, saying what was missing", async () => {
     server = await startControlServer({ snapshotDir: "/unused" });
     const response = await fetch(`http://127.0.0.1:${server.port}/snapshot`);
     expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toContain("?name=");
   });
 
-  it("returns 404 for unknown paths", async () => {
+  it("returns 404 for unknown paths, naming the path", async () => {
     server = await startControlServer({ snapshotDir: "/unused" });
     const response = await fetch(`http://127.0.0.1:${server.port}/nope`);
     expect(response.status).toBe(404);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toContain("/nope");
   });
-});
-
-describe("control server lifecycle", () => {
-  it("does not keep the host process alive", async () => {
-    // Found while probing Node 24.4: an open control socket kept the measured
-    // process running forever. Measuring must not change what is measured.
-    const { execFileSync } = await import("node:child_process");
-    const { fileURLToPath } = await import("node:url");
-    const pathModule = await import("node:path");
-    const { mkdtemp } = await import("node:fs/promises");
-    const { tmpdir } = await import("node:os");
-
-    const rootDir = fileURLToPath(new URL("..", import.meta.url));
-    const workDir = await mkdtemp(pathModule.join(tmpdir(), "next-leak-unref-"));
-    const started = Date.now();
-    execFileSync(
-      process.execPath,
-      ["--import", `file://${pathModule.join(rootDir, "dist", "bootstrap.js")}`, "-e", "0"],
-      { env: { ...process.env, NEXT_LEAK_DIR: workDir }, timeout: 20_000 }
-    );
-    // Without unref() this never returns.
-    expect(Date.now() - started).toBeLessThan(15_000);
-  }, 30_000);
-
-  it("announces one control file per process id", async () => {
-    const { readdir, mkdtemp } = await import("node:fs/promises");
-    const { execFileSync } = await import("node:child_process");
-    const { fileURLToPath } = await import("node:url");
-    const pathModule = await import("node:path");
-    const { tmpdir } = await import("node:os");
-
-    const rootDir = fileURLToPath(new URL("..", import.meta.url));
-    const workDir = await mkdtemp(pathModule.join(tmpdir(), "next-leak-pids-"));
-    const bootstrap = `file://${pathModule.join(rootDir, "dist", "bootstrap.js")}`;
-    for (let i = 0; i < 2; i += 1) {
-      execFileSync(process.execPath, ["--import", bootstrap, "-e", "0"], {
-        env: { ...process.env, NEXT_LEAK_DIR: workDir },
-        timeout: 20_000,
-      });
-    }
-    const files = (await readdir(workDir)).filter((name) => name.startsWith("control-"));
-    // Two processes → two announcements, no overwriting.
-    expect(files).toHaveLength(2);
-  }, 40_000);
 });

--- a/src/launcher-messages.test.ts
+++ b/src/launcher-messages.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { explainRuntimeFailure, explainStartupFailure } from "./launcher.js";
+
+// Pure message functions, split from launcher.test.ts (which boots real
+// processes and is excluded from mutation runs) so mutation can judge the
+// half of the launcher that is judgeable without spawning anything.
+// Hit while validating webpack builds: a standalone bundle shipped without
+// @swc/helpers. The tool was the messenger; the message was a stack dump.
+describe("explainStartupFailure", () => {
+  it("turns a missing dependency into an actionable sentence", () => {
+    const message = explainStartupFailure(
+      "Error: Cannot find module '@swc/helpers/_/_interop_require_default'\n  at ..."
+    );
+    expect(message).toContain("@swc/helpers/_/_interop_require_default");
+    expect(message).toContain("build problem, not a measurement one");
+    // Every clause of this sentence is the remedy someone follows at 2am.
+    expect(message).toContain("fails the same way on its own");
+    expect(message).toContain("copy the missing package into");
+    expect(message).not.toContain("at ...");
+  });
+
+  it("names a port clash plainly", () => {
+    expect(explainStartupFailure("listen EADDRINUSE 127.0.0.1:3000")).toContain("port was taken");
+  });
+
+  it("falls back to the raw stderr when the cause is unknown", () => {
+    expect(explainStartupFailure("something odd happened")).toContain("something odd happened");
+  });
+});
+
+// A process killed by the heap limit used to surface as "fetch failed" three
+// calls later, which reads like a bug in the tool instead of the finding it is.
+describe("explainRuntimeFailure", () => {
+  const V8_FATAL = [
+    "<--- Last few GCs --->",
+    "[3314:0xde692d0] 178177 ms: Mark-Compact 2617.4 (2653.9) -> 2214.5 (2274.8) MB",
+    "FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory",
+  ].join("\n");
+
+  it("names heap exhaustion, the limit in force, and the way out", () => {
+    const message = explainRuntimeFailure(V8_FATAL, 512);
+    expect(message).toContain("ran out of heap");
+    expect(message).toContain("--max-old-space-size=512");
+    expect(message).toContain("does not fit in 512 MB under this load");
+    expect(message).toContain("--max-old-space <mb>");
+    expect(message).toContain("--requests/--connections");
+  });
+
+  it("recognises the ineffective mark-compact wording too", () => {
+    const message = explainRuntimeFailure(
+      "FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed",
+      4096
+    );
+    expect(message).toContain("4096 MB");
+  });
+
+  it("falls back to the startup explanation for any other death", () => {
+    expect(explainRuntimeFailure("Error: Cannot find module 'x'", 512)).toContain(
+      "build problem"
+    );
+  });
+});

--- a/src/launcher.test.ts
+++ b/src/launcher.test.ts
@@ -4,12 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
-import {
-  explainRuntimeFailure,
-  explainStartupFailure,
-  launchInstrumented,
-  type LaunchedApp,
-} from "./launcher.js";
+import { launchInstrumented, type LaunchedApp } from "./launcher.js";
 
 const rootDir = fileURLToPath(new URL("..", import.meta.url));
 const bootstrapPath = path.join(rootDir, "dist", "bootstrap.js");
@@ -80,57 +75,4 @@ describe("launchInstrumented", () => {
       })
     ).rejects.toMatchObject({ name: "LaunchError" });
   }, 30_000);
-});
-
-// Hit while validating webpack builds: a standalone bundle shipped without
-// @swc/helpers. The tool was the messenger; the message was a stack dump.
-describe("explainStartupFailure", () => {
-  it("turns a missing dependency into an actionable sentence", () => {
-    const message = explainStartupFailure(
-      "Error: Cannot find module '@swc/helpers/_/_interop_require_default'\n  at ..."
-    );
-    expect(message).toContain("@swc/helpers/_/_interop_require_default");
-    expect(message).toContain("build problem, not a measurement one");
-    expect(message).not.toContain("at ...");
-  });
-
-  it("names a port clash plainly", () => {
-    expect(explainStartupFailure("listen EADDRINUSE 127.0.0.1:3000")).toContain("port was taken");
-  });
-
-  it("falls back to the raw stderr when the cause is unknown", () => {
-    expect(explainStartupFailure("something odd happened")).toContain("something odd happened");
-  });
-});
-
-// A process killed by the heap limit used to surface as "fetch failed" three
-// calls later, which reads like a bug in the tool instead of the finding it is.
-describe("explainRuntimeFailure", () => {
-  const V8_FATAL = [
-    "<--- Last few GCs --->",
-    "[3314:0xde692d0] 178177 ms: Mark-Compact 2617.4 (2653.9) -> 2214.5 (2274.8) MB",
-    "FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory",
-  ].join("\n");
-
-  it("names heap exhaustion, the limit in force, and the way out", () => {
-    const message = explainRuntimeFailure(V8_FATAL, 512);
-    expect(message).toContain("ran out of heap");
-    expect(message).toContain("--max-old-space-size=512");
-    expect(message).toContain("--max-old-space");
-    expect(message).toContain("--requests");
-  });
-
-  it("recognises the ineffective mark-compact wording too", () => {
-    const message = explainRuntimeFailure(
-      "FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed",
-      4096
-    );
-    expect(message).toContain("4096 MB");
-  });
-
-  it("falls back to the startup explanation for any other death", () => {
-    expect(explainRuntimeFailure("Error: Cannot find module 'x'", 512)).toContain(
-      "build problem"
-    );
-  });
 });

--- a/src/load.test.ts
+++ b/src/load.test.ts
@@ -77,6 +77,69 @@ describe("runLoadPhase", () => {
   }, 30_000);
 });
 
+// Killed mutants: the redirect explainer's status window, the error budget's
+// exact boundary, and the failure message's arithmetic were all mutable
+// without a test noticing.
+describe("mutation-hardening: load", () => {
+  it("names the redirect target across the whole 3xx window, and only there", async () => {
+    const at = async (status: number, location?: string): Promise<() => Promise<unknown>> => {
+      const port = await listen((_req, res) => {
+        res.statusCode = status;
+        if (location !== undefined) {
+          res.setHeader("location", location);
+        }
+        res.end();
+      });
+      return () => runLoadPhase({ url: `http://127.0.0.1:${port}/`, amount: 20, connections: 2 });
+    };
+
+    // 300 is inside the window: the message must point at the target.
+    await expect((await at(300, "/es"))()).rejects.toThrow(/redirects \(300\) to "\/es"/);
+    await new Promise<void>((resolve) => (server ? server.close(() => resolve()) : resolve()));
+
+    // 400 is outside it: a location header there is not a redirect.
+    await expect((await at(400, "/es"))()).rejects.toThrow(LoadError);
+    await expect((await at(400, "/es"))()).rejects.not.toThrow(/redirects/);
+  }, 30_000);
+
+  it("tolerates failures exactly at the error budget", async () => {
+    // 1 failure in 100 requests sits exactly ON the 1% budget: the phase must
+    // pass — the budget is "more than", not "at least".
+    let served = 0;
+    const port = await listen((_req, res) => {
+      served += 1;
+      res.statusCode = served === 1 ? 500 : 200;
+      res.end("ok");
+    });
+    const result = await runLoadPhase({
+      url: `http://127.0.0.1:${port}/`,
+      amount: 100,
+      connections: 1,
+    });
+    expect(result.non2xx).toBe(1);
+  }, 30_000);
+
+  it("does not report phantom unanswered requests when every failure answered", async () => {
+    // Every request gets a real 500: failures == non2xx, so the "no recorded
+    // response" clause must stay out of the message. A sign flip in that
+    // arithmetic invents unanswered requests out of answered ones.
+    const port = await listen((_req, res) => {
+      res.statusCode = 500;
+      res.end();
+    });
+    await runLoadPhase({ url: `http://127.0.0.1:${port}/`, amount: 30, connections: 3 }).then(
+      () => {
+        throw new Error("expected a LoadError");
+      },
+      (error: unknown) => {
+        const message = String((error as Error).message);
+        expect(message).toContain("30 non-2xx");
+        expect(message).not.toContain("no recorded response");
+      }
+    );
+  }, 30_000);
+});
+
 // Leaks keyed by URL (route caches, LRUs — vercel/next.js#94890) are invisible
 // when every request hits the same path.
 describe("unique URL generation", () => {

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -36,7 +36,11 @@
     "src/peak-pressure.ts",
     "src/abandon-load.ts",
     "src/ritual.ts",
-    "src/runner.ts"
+    "src/runner.ts",
+    "src/load.ts",
+    "src/control-server.ts",
+    "src/launcher.ts",
+    "src/control-client.ts"
   ],
   "thresholds": {
     "high": 90,

--- a/vitest.mutation.config.ts
+++ b/vitest.mutation.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       // exactly the cost mutation runs cannot afford per mutant.
       "src/bootstrap.test.ts",
       "src/cli-surface.test.ts",
+      "src/control-lifecycle.test.ts",
     ],
   },
 });


### PR DESCRIPTION
Final batch of the audit: `load.ts`, `launcher.ts`, `control-server.ts`, `control-client.ts` — the modules that talk to real processes, previously outside mutation entirely.

## Structural moves

- The two process-spawning lifecycle tests split out of `control-server.test.ts` into `control-lifecycle.test.ts`: they reference `dist/`, which Stryker's sandbox does not carry, and broke every dry run.
- The pure message functions split out of `launcher.test.ts` into `launcher-messages.test.ts`, so mutation can judge the half of the launcher that needs no spawning.

## What the survivors revealed

- **`deadlineFor` could map `/snapshot?name=x` to the 30-second default** instead of its 30-minute bound — quietly reinstating, from the inside, the exact hidden snapshot ceiling the control-channel rewrite (#35) exists to remove. Killed via a seam over the pure mapping.
- **`/mem`'s `gcExposed` flag was invertible**, and `forceGc` could run four passes instead of the validated three — silently changing every post-GC sample's regime.
- `requestGc`/`requestSnapshot` never had their `--expose-gc` refusal exercised.
- **The redirect explainer's 3xx window was mutable at both edges**: 300-with-location must be described, 400-with-location must not.
- **The error budget was off-by-one-able**: 1 failure in 100 requests sits exactly ON the 1% budget and must pass — the budget is "more than", not "at least".
- The failure message could report phantom *"no recorded response"* requests out of failures that all answered (sign flip in the `unanswered` arithmetic).

## Scores

| module | before | after |
|---|---|---|
| `control-server.ts` | 64.6% | **79.3%** |
| `control-client.ts` | 74.3% | **92.9%** |
| `load.ts` | unmeasured | ~77% |
| `launcher.ts` | unmeasured | **89.3% of covered** |

`launcher.ts`'s 100 no-coverage mutants are the process domain itself — spawn, readiness polls, teardown — judged by the integration suites on every `pnpm test`, not by mutation. That boundary, plus four other remainder classes (Promise-settle guards, loopback listen params, the legacy abandon path, mixed-failure-only arithmetic), is recorded in the equivalent-mutants register. All four modules join the weekly mutate list.

Also flagged for a separate change (chip filed): `load.ts` still carries the **legacy autocannon-timeout abandon path** production no longer uses — two implementations of one concept is the drift class that already bit once.

## Gate

**450 tests**, suite ×3 green · typecheck · build · pack-smoke on the installed 0.4.3 tarball.