### PR TITLE
refactor!: remove the legacy autocannon-timeout abandon path from the load phase

### DIFF
--- a/src/load.test.ts
+++ b/src/load.test.ts
@@ -190,37 +190,3 @@ describe("request headers", () => {
   }, 30_000);
 });
 
-// Leaks that only exist when the client gives up (vercel/next.js#89091 traces
-// ServerResponse retention to an early disconnect) are unreachable with a load
-// generator that always waits for the response.
-describe("client abandonment", () => {
-  it("does not count deliberate abandonment as failure", async () => {
-    const port = await listen((req, res) => {
-      // Never answers within the abandon window.
-      setTimeout(() => res.end("late"), 5000).unref();
-    });
-    const result = await runLoadPhase({
-      url: `http://127.0.0.1:${port}/slow`,
-      amount: 10,
-      connections: 5,
-      abandonAfterMs: 1000,
-    });
-    expect(result.timeouts).toBeGreaterThan(0);
-    expect(result.ok2xx).toBe(0);
-  }, 30_000);
-
-  it("still fails when responses error rather than being abandoned", async () => {
-    const port = await listen((req, res) => {
-      res.statusCode = 500;
-      res.end();
-    });
-    await expect(
-      runLoadPhase({
-        url: `http://127.0.0.1:${port}/boom`,
-        amount: 20,
-        connections: 5,
-        abandonAfterMs: 1000,
-      })
-    ).rejects.toBeInstanceOf(LoadError);
-  }, 30_000);
-});

--- a/src/load.ts
+++ b/src/load.ts
@@ -9,12 +9,6 @@ export type LoadPhaseOptions = {
   /** Sent with every request (compression, cookies, auth). */
   headers?: Record<string, string>;
   /**
-   * Give up on each request after this many milliseconds, emulating clients
-   * that disconnect before the response arrives. Abandoned requests are
-   * expected, so they do not count against the error budget.
-   */
-  abandonAfterMs?: number;
-  /**
    * Maximum tolerated ratio of non-2xx responses plus socket errors before
    * the phase fails. A route that errors under load must fail the run, not
    * silently measure garbage. Default: 0.01 (1%).
@@ -71,9 +65,6 @@ export async function runLoadPhase(options: LoadPhaseOptions): Promise<LoadPhase
     amount: options.amount,
     connections: options.connections,
     ...(options.headers !== undefined && { headers: options.headers }),
-    ...(options.abandonAfterMs !== undefined && {
-      timeout: Math.max(Math.ceil(options.abandonAfterMs / 1000), 1),
-    }),
     ...(unique && { idReplacement: true }),
   });
 
@@ -91,9 +82,12 @@ export async function runLoadPhase(options: LoadPhaseOptions): Promise<LoadPhase
   // autocannon report requests as sent with zero recorded responses, which
   // the narrower check accepted: the route was never really loaded, yet it
   // would have produced a confident "stable" verdict.
-  // When abandoning on purpose, timeouts are the point of the exercise.
-  const expected = options.abandonAfterMs === undefined ? 0 : result.timeouts;
-  const failures = Math.max(options.amount - result.ok2xx - expected, 0);
+  //
+  // Client abandonment deliberately has no seat here: it once did, via
+  // autocannon's whole-second timeout, which cannot abandon a route that
+  // answers in milliseconds and cut before the first byte besides. The
+  // raw-socket phase (abandon-load.ts) is the one implementation.
+  const failures = Math.max(options.amount - result.ok2xx, 0);
   const ratio = options.amount === 0 ? 0 : failures / options.amount;
   if (ratio > (options.maxErrorRatio ?? 0.01)) {
     const unanswered = failures - result.non2xx - result.errors - result.timeouts;


### PR DESCRIPTION
Re-lands #40, which was approved and merged — but into its stacked base (`test/process-boundary-mutation`) minutes after #39's squash was cut, so the removal never reached `main`. Same commit, cherry-picked onto current main; `src/load.ts` on main still carries the legacy path today.

Original rationale and verification in #40: two client-abandonment implementations coexisted; the removed one rode autocannon's whole-second timeout, cut pre-first-byte (the semantics `fix-abandon-first-byte` corrected everywhere else), and was reachable only from its own two tests. The `measurement-loop` spec now states there is exactly one disconnect implementation.

**BREAKING (library API)**: `LoadPhaseOptions` no longer accepts `abandonAfterMs`. CLI and `next-leak.config.json` unchanged.

Gate re-run on this branch: **448 tests** green · mutation of `load.ts` drops from 84 mutants / 18 survivors to 72 / 15.