### PR TITLE
test: cover the Pages-only target branch and the first-contact messages

### DIFF
--- a/src/environment.test.ts
+++ b/src/environment.test.ts
@@ -1,0 +1,21 @@
+import os from "node:os";
+import { describe, expect, it } from "vitest";
+import { captureEnvironment } from "./environment.js";
+
+// Two mutants survived here for want of any direct test: the cpuModel
+// fallback could be forced to null, hiding the CPU from every report and
+// issue draft that quotes it.
+describe("captureEnvironment", () => {
+  it("captures the real machine, not placeholders", () => {
+    const environment = captureEnvironment("16.2.2");
+    expect(environment.nodeVersion).toBe(process.version);
+    expect(environment.platform).toBe(os.platform());
+    expect(environment.arch).toBe(os.arch());
+    // Every machine this runs on has at least one CPU with a model string.
+    expect(environment.cpuModel).toBe(os.cpus()[0]?.model);
+    expect(environment.cpuModel).not.toBeNull();
+    expect(environment.totalMemoryBytes).toBe(os.totalmem());
+    expect(environment.nextVersion).toBe("16.2.2");
+    expect(environment.nextLeakVersion).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});

--- a/src/target.test.ts
+++ b/src/target.test.ts
@@ -33,6 +33,22 @@ describe("validateTarget", () => {
     });
   });
 
+  it("walks the user through enabling standalone output, verbatim", async () => {
+    // This is the first wall every new user hits: the message IS the product
+    // there, and every clause of it is load-bearing — the config snippet, the
+    // rebuild step, and the reassurance that packaging is all that changes.
+    const appDir = await makeAppDir();
+    await mkdir(path.join(appDir, ".next"), { recursive: true });
+    const failure = await validateTarget(appDir).catch((cause: TargetError) => cause);
+    expect(failure).toBeInstanceOf(TargetError);
+    const message = (failure as TargetError).message;
+    expect(message).toContain('output: "standalone"');
+    expect(message).toContain("// ...your existing config");
+    expect(message).toContain("then rebuild:  next build");
+    expect(message).toContain("not how your app behaves");
+    expect(message).toContain(path.join(".next", "standalone", "server.js"));
+  });
+
   it("fails with NO_STANDALONE when the standalone server is missing", async () => {
     const appDir = await makeAppDir();
     await mkdir(path.join(appDir, ".next"), { recursive: true });
@@ -58,6 +74,39 @@ describe("validateTarget", () => {
     );
     expect(target.appPaths["/page"]).toBe("app/page.js");
     expect(target.routes?.version).toBe(3);
+  });
+
+  it("accepts a Pages-only build — server leaks are not App Router exclusive", async () => {
+    // Validated end to end against the vercel/next.js#95094 reproduction
+    // (Pages Router + middleware), but the unit suite never touched the
+    // branch: 11 of target.ts's mutants sat in it with no coverage at all.
+    const appDir = await makeAppDir();
+    await mkdir(path.join(appDir, ".next", "standalone"), { recursive: true });
+    await mkdir(path.join(appDir, ".next", "server"), { recursive: true });
+    await writeFile(path.join(appDir, ".next", "standalone", "server.js"), "// stub\n");
+    await writeFile(
+      path.join(appDir, ".next", "server", "pages-manifest.json"),
+      JSON.stringify({ "/about": "pages/about.js", "/api/heap": "pages/api/heap.js" })
+    );
+
+    const target = await validateTarget(appDir);
+    expect(Object.keys(target.pages)).toEqual(["/about", "/api/heap"]);
+    expect(target.appPaths).toEqual({});
+  });
+
+  it("names both missing manifests when a build has neither", async () => {
+    const appDir = await makeAppDir();
+    await mkdir(path.join(appDir, ".next", "standalone"), { recursive: true });
+    await mkdir(path.join(appDir, ".next", "server"), { recursive: true });
+    await writeFile(path.join(appDir, ".next", "standalone", "server.js"), "// stub\n");
+
+    const failure = await validateTarget(appDir).catch((cause: TargetError) => cause);
+    expect(failure).toBeInstanceOf(TargetError);
+    expect((failure as TargetError).code).toBe("BAD_MANIFEST");
+    const message = (failure as TargetError).message;
+    expect(message).toContain("app-paths-manifest.json");
+    expect(message).toContain("pages-manifest.json");
+    expect(message).toContain('"next build"');
   });
 
   it("exposes the error code on the class for programmatic handling", () => {


### PR DESCRIPTION
Follow-up to the mutation audit, prompted by the first full-sweep run across all 22 modules (**80.8% total / 86.3% of covered**). Two modules stood out below the line and both turned out to hide something real.

## `target.ts` — 57.4% → 80.3%

Reading the survivors found an actual coverage hole, not test debt: **the Pages-only branch had no unit test at all**. A build with `pages-manifest.json` and no App Router manifest — supported since the "server leaks are not App Router exclusive" fix, and validated e2e against the #95094 reproduction (Pages Router + middleware) — left 11 mutants unjudged: the manifest path could be emptied and the `pages`/`appPaths` distinction inverted silently.

Also pinned, because this module is every new user's first contact and its messages are the product there:

- every clause of the `NO_STANDALONE` walkthrough (the `output: "standalone"` snippet, the rebuild step, the "only packaging changes" reassurance)
- `BAD_MANIFEST` naming both manifests and the rebuild command

## `environment.ts` — 50% → 75%

Its `cpuModel` fallback could be forced to `null`, hiding the CPU from every report and issue draft that quotes it. The remaining survivor is the `cpus()[0]` optional-chain guard — unreachable on any machine that has a CPU.

## Gate

**452 tests**, suite ×3 green · typecheck · build.

Note: #41 (the re-landed legacy-abandon removal) is still open and independent of this branch.