### PR TITLE
fix: keep both ends of the measured process's stderr, not just the tail

### DIFF
--- a/src/launcher-messages.test.ts
+++ b/src/launcher-messages.test.ts
@@ -59,4 +59,27 @@ describe("explainRuntimeFailure", () => {
       "build problem"
     );
   });
+
+  it("recognises a REAL-sized fatal dump, where the FATAL line is nowhere near the end", () => {
+    // A genuine V8 OOM dump: GC trace, the one load-bearing line, then ~75
+    // native frames pushing it thousands of characters from the tail. The
+    // measured process on the vercel/next.js#89091 repro died exactly like
+    // this and was reported as a generic exit, because only a 2000-char tail
+    // was kept.
+    const frames = Array.from(
+      { length: 75 },
+      (_, index) =>
+        `${index + 1}: 0x108e3a4${String(index).padStart(2, "0")} node::SomeVeryLongNativeFrameName::WithTemplates<v8::internal::DirectHandle<v8::internal::Object>>(v8::FunctionCallbackInfo<v8::Value> const&) [/opt/homebrew/lib/libnode.141.dylib]`
+    ).join("\n");
+    const dump =
+      "<--- Last few GCs --->\n" +
+      "[48563:0xb65c00000] 26941 ms: Scavenge 496.6 (505.3) -> 493.7 (506.1) MB\n" +
+      "FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory\n" +
+      "----- Native stack trace -----\n" +
+      frames;
+    expect(dump.length).toBeGreaterThan(8000);
+    // The window handed to the explainer must still contain the FATAL line.
+    const window = `${dump.slice(0, 4096)}\n[...]\n${dump.slice(-4096)}`;
+    expect(explainRuntimeFailure(window, 512)).toContain("ran out of heap");
+  });
 });

--- a/src/launcher.test.ts
+++ b/src/launcher.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, stat } from "node:fs/promises";
+import { mkdtemp, stat, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -62,6 +62,43 @@ describe("launchInstrumented", () => {
     await app.close();
     app = undefined;
     await expect(fetch(`http://127.0.0.1:${port}/`)).rejects.toThrow();
+  }, 30_000);
+
+  it("keeps both ends of a long fatal dump, so the FATAL line survives the frames", async () => {
+    // The field case: a real V8 OOM dump is >8 KB with its one load-bearing
+    // line at the top and ~75 native frames after it. A tail-only window
+    // reported an anonymous C++ stack; the head must survive.
+    const workDir = await mkdtemp(path.join(tmpdir(), "next-leak-dump-"));
+    const dumpServer = path.join(workDir, "dumping-server.js");
+    const frames = Array.from(
+      { length: 80 },
+      (_, index) => `${index + 1}: 0xdeadbeef${index} node::SomeNativeFrame::Invoke(v8::FunctionCallbackInfo<v8::Value> const&) [libnode.dylib]`
+    ).join("\n");
+    await writeFile(
+      dumpServer,
+      `process.stderr.write("FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory\\n");
+` +
+        `process.stderr.write(${JSON.stringify(frames)});
+` +
+        `process.exit(134);
+`
+    );
+
+    const failure = await launchInstrumented({
+      serverPath: dumpServer,
+      workDir,
+      appPort: await freePort(),
+      bootstrapPath,
+      readyTimeoutMs: 10_000,
+    }).catch((cause: Error) => cause);
+
+    expect(failure).toBeInstanceOf(Error);
+    const message = (failure as Error).message;
+    // Head: the line that names the failure. Tail: the last frames. Marker:
+    // proof the window really joined two ends instead of keeping one.
+    expect(message).toContain("FATAL ERROR: Ineffective mark-compacts");
+    expect(message).toContain("[...]");
+    expect(message).toContain("80: 0xdeadbeef79");
   }, 30_000);
 
   it("fails with the child's stderr when the server crashes on boot", async () => {

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -55,6 +55,13 @@ export class LaunchError extends Error {
 
 const activeChildren = new Set<ChildProcess>();
 
+/**
+ * Characters of stderr kept from each end of the stream. 4096 comfortably
+ * holds a fatal header (GC trace + FATAL line) on one side and the last
+ * frames plus any explanatory epilogue on the other.
+ */
+const STDERR_WINDOW = 4096;
+
 /** Interrupt safety: no measured-app process may outlive the CLI. */
 export function killActiveChildren(): void {
   for (const child of activeChildren) {
@@ -159,10 +166,25 @@ export async function launchInstrumented(options: LaunchOptions): Promise<Launch
     }
   );
 
-  let stderrTail = "";
+  // Head AND tail, not tail alone. A real V8 fatal dump puts its one
+  // load-bearing line ("FATAL ERROR: ... heap out of memory") ahead of ~75
+  // native stack frames, several thousand characters before the end — a
+  // tail-only window showed an anonymous C++ stack and the OOM recognition
+  // below never fired. Found measuring the vercel/next.js#89091 repro, whose
+  // measured process died at the cap and was reported as a generic exit.
+  let stderrHead = "";
+  let stderrTailBuffer = "";
   child.stderr?.on("data", (chunk: Buffer) => {
-    stderrTail = (stderrTail + chunk.toString()).slice(-2000);
+    const text = chunk.toString();
+    if (stderrHead.length < STDERR_WINDOW) {
+      stderrHead = (stderrHead + text).slice(0, STDERR_WINDOW);
+    }
+    stderrTailBuffer = (stderrTailBuffer + text).slice(-STDERR_WINDOW);
   });
+  const stderrWindow = (): string =>
+    stderrHead === stderrTailBuffer || stderrTailBuffer === ""
+      ? stderrHead
+      : `${stderrHead}\n[...]\n${stderrTailBuffer}`;
   let exited = false;
   activeChildren.add(child);
   child.once("exit", () => {
@@ -170,7 +192,7 @@ export async function launchInstrumented(options: LaunchOptions): Promise<Launch
     activeChildren.delete(child);
   });
   const failed = (): string | undefined =>
-    exited ? `server exited before becoming ready. ${explainStartupFailure(stderrTail)}` : undefined;
+    exited ? `server exited before becoming ready. ${explainStartupFailure(stderrWindow())}` : undefined;
 
   try {
     const controlPort = await pollUntil(
@@ -225,7 +247,7 @@ export async function launchInstrumented(options: LaunchOptions): Promise<Launch
       controlPort,
       explainExit: () =>
         exited
-          ? explainRuntimeFailure(stderrTail, options.maxOldSpaceMb ?? DEFAULT_MAX_OLD_SPACE_MB)
+          ? explainRuntimeFailure(stderrWindow(), options.maxOldSpaceMb ?? DEFAULT_MAX_OLD_SPACE_MB)
           : null,
       close: async () => {
         if (exited) {


### PR DESCRIPTION
Found in the field, measuring the [vercel/next.js#89091](https://github.com/vercel/next.js/issues/89091) reproduction with 0.5.0.

## The bug

The measured process died at its 512 MB cap and the route was reported as a generic mid-run exit trailing ~15 anonymous C++ frames — while the OOM recognition shipped in 0.3.0 sat silent. Reason: a real V8 fatal dump puts `FATAL ERROR: ... JavaScript heap out of memory` **ahead of ~75 native stack frames**, several thousand characters before the end of the stream, and the launcher kept only a 2000-character tail. The unit test guarding the feature used a synthetic dump short enough to fit — a test-shaped dump, not a real-shaped one.

## The fix

Keep **head and tail** (4096 chars each, joined with `[...]`) and feed that window to both failure explainers. The new test builds a >8000-char dump with the FATAL line near the top, like the real ones.

Verified end to end against the same repro: the 512 MB run now fails with

```
the measured process ran out of heap and was killed by V8 mid-run
(limit in force: --max-old-space-size=512 MB). That is the measurement ...
Raise it with --max-old-space <mb> ...
```

## What the hunt that found this also found

With the corrected window and a 4 GB cap, the #89091 leak — which this tool previously called `stable` under the broken pre-first-byte abort timing — reproduces unambiguously on next 16.1.5 + Node 25.7:

| variant | verdict |
|---|---|
| gzip + mid-stream aborts | **leak +42.54 MB/1000 req** (27 → 537 MB over 6 cycles) |
| gzip, no aborts | stable +0.01 |
| aborts, no gzip | stable +0.03 |

(Sent upstream separately; kept out of this PR.)

## Gate

**453 tests**, suite ×3 green · typecheck · build · pack-smoke.