### PR TITLE
feat: close the silent false negatives, and measure builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ checked 2026-08-18:
 |---|---|---|---|
 | [#96533](https://github.com/vercel/next.js/issues/96533) | ISR revalidation holds RSC buffers between collections | 4–5 MB of `arrayBuffers` held vs 0.32 MB retained | **open** |
 | [#97464](https://github.com/vercel/next.js/issues/97464) | Static-gen worker retains per prerendered page | worker rss 1.07 → 2.96 GB, then OOM | **open** |
-| [#92287](https://github.com/vercel/next.js/issues/92287) | Cache Components: unbounded `arrayBuffers` under load | peaked 3.1 GB while retaining 36 MB | **open** |
+| [#92287](https://github.com/vercel/next.js/issues/92287) | Cache Components: unbounded `arrayBuffers` under load | 37.5 MB of arrayBuffers held between collections, 37x what it retains (16.3.1) | **open** |
 | [#84884](https://github.com/vercel/next.js/issues/84884) | axios + `AbortSignal` in middleware | 32.8 → 369.9 MB | **open** |
-| [#89091](https://github.com/vercel/next.js/issues/89091) | zlib retention on mid-stream aborts | +42.5 MB per 1000 aborted requests | **open** |
+| [#89091](https://github.com/vercel/next.js/issues/89091) | zlib retention on mid-stream aborts | +42.5 MB/1000 aborted req on 16.1.5; **+0.03 on 16.3.1** | open, no longer reproduces |
 | [#95094](https://github.com/vercel/next.js/issues/95094) | Middleware `setTimeout` ids retained by the sandbox | 112 MB retained; flat after the fix | fixed in 16.3.0 |
 | [#94890](https://github.com/vercel/next.js/issues/94890) | Router LRU cache doesn't count its keys | 26.7 → 71.9 MB | fixed in 16.3.0 |
 | [#94919](https://github.com/vercel/next.js/issues/94919) | Retention on client aborts | 39 → 139 MB · [with a caveat](#scope-and-limits-read-before-filing-issues) | fixed in 16.3.0 |
@@ -47,7 +47,9 @@ looks impressive until the bugs close, and what those rows show is that the
 measurements matched what the fixes turned out to be. #94919 is the sharpest —
 the PR that closed it discarded the RSC-WeakMap hypothesis in the title and
 attributed the leak to native zlib retention instead, which is the same
-mechanism the #89091 measurement had already isolated.
+mechanism the #89091 measurement had already isolated — and re-measuring #89091
+on 16.3.1 (2026-08-18) shows it gone, from +42.5 MB per 1000 aborted requests
+down to +0.03, which is the same fix arriving from the other direction.
 
 The full causal chain, measured on that same issue: leak found (28.7 -> 138.9 MB
 across 8 cycles), the workaround from the thread applied (`clearTimeout(id)`
@@ -222,8 +224,10 @@ the verdict:
 ```
 
 That is a real measurement of the reproduction in
-[vercel/next.js#92287](https://github.com/vercel/next.js/issues/92287): no
-retention, and 3 GB reached. The note fires when the peak heap comes within
+[vercel/next.js#92287](https://github.com/vercel/next.js/issues/92287) on
+16.2.2: no retention, and 3 GB reached under its own sustained load. The same
+app on 16.3.1 under a shorter profile still reaches 544 MB against 33.8 MB
+retained, so the shape has not gone anywhere. The note fires when the peak heap comes within
 75% of `--max-old-space`, or when peak RSS is at least 8× the retained heap
 and above 512 MB. It never changes the verdict — retention and peak are
 different questions, and only one of them is a leak. A peak is the highest

--- a/README.md
+++ b/README.md
@@ -23,19 +23,31 @@ $ npx next-leak . --quick
 ```
 
 That first line is a real run against the reproduction for
-[vercel/next.js#95094](https://github.com/vercel/next.js/issues/95094), an open
-Next.js issue: the sandbox's `TimeoutsManager` never releases timeout ids from
-middleware. next-leak found the growth, the retaining object and the chain that
-holds it — without being told what to look for.
+[vercel/next.js#95094](https://github.com/vercel/next.js/issues/95094): the
+sandbox's `TimeoutsManager` never released timeout ids from middleware.
+next-leak found the growth, the retaining object and the chain that holds it —
+without being told what to look for. Next.js 16.3.0 has since fixed it.
 
-**Verified against real, open Next.js issues**, not synthetic fixtures:
+**Verified against real Next.js issues**, not synthetic fixtures. Issue states
+checked 2026-08-18:
 
-| Issue | What it is | Result |
-|---|---|---|
-| [#95094](https://github.com/vercel/next.js/issues/95094) | Middleware `setTimeout` ids retained by the sandbox | **Reproduced** · mechanism named · 112 MB retained |
-| [#94890](https://github.com/vercel/next.js/issues/94890) | Router LRU cache doesn't count its keys | **Reproduced** · 26.7 → 71.9 MB |
-| [#84884](https://github.com/vercel/next.js/issues/84884) | axios + `AbortSignal` in middleware | **Reproduced** · 32.8 → 369.9 MB |
-| [#94919](https://github.com/vercel/next.js/issues/94919) | RSC tree retained on client aborts | **Reproduced** · 39 → 139 MB · [with a caveat](#scope-and-limits-read-before-filing-issues) |
+| Issue | What it is | Measured | State today |
+|---|---|---|---|
+| [#96533](https://github.com/vercel/next.js/issues/96533) | ISR revalidation holds RSC buffers between collections | 4–5 MB of `arrayBuffers` held vs 0.32 MB retained | **open** |
+| [#97464](https://github.com/vercel/next.js/issues/97464) | Static-gen worker retains per prerendered page | worker rss 1.07 → 2.96 GB, then OOM | **open** |
+| [#92287](https://github.com/vercel/next.js/issues/92287) | Cache Components: unbounded `arrayBuffers` under load | peaked 3.1 GB while retaining 36 MB | **open** |
+| [#84884](https://github.com/vercel/next.js/issues/84884) | axios + `AbortSignal` in middleware | 32.8 → 369.9 MB | **open** |
+| [#89091](https://github.com/vercel/next.js/issues/89091) | zlib retention on mid-stream aborts | +42.5 MB per 1000 aborted requests | **open** |
+| [#95094](https://github.com/vercel/next.js/issues/95094) | Middleware `setTimeout` ids retained by the sandbox | 112 MB retained; flat after the fix | fixed in 16.3.0 |
+| [#94890](https://github.com/vercel/next.js/issues/94890) | Router LRU cache doesn't count its keys | 26.7 → 71.9 MB | fixed in 16.3.0 |
+| [#94919](https://github.com/vercel/next.js/issues/94919) | Retention on client aborts | 39 → 139 MB · [with a caveat](#scope-and-limits-read-before-filing-issues) | fixed in 16.3.0 |
+
+The three fixed ones are kept deliberately: a tool that only lists open bugs
+looks impressive until the bugs close, and what those rows show is that the
+measurements matched what the fixes turned out to be. #94919 is the sharpest —
+the PR that closed it discarded the RSC-WeakMap hypothesis in the title and
+attributed the leak to native zlib retention instead, which is the same
+mechanism the #89091 measurement had already isolated.
 
 The full causal chain, measured on that same issue: leak found (28.7 -> 138.9 MB
 across 8 cycles), the workaround from the thread applied (`clearTimeout(id)`
@@ -102,11 +114,26 @@ Every report prints the gate it used.
 | `--requests <n>` | 5000 | Requests per cycle. Raises sensitivity as well as duration: the growth gate scales with it, down to a noise floor around 5000 |
 | `--connections <n>` | 100 | Concurrent connections |
 | `--idle <seconds>` | 30 | **Maximum** wait before each sample; the run continues as soon as the heap settles |
+| `--warmup <n>` | 200 | Requests before the baseline snapshot. Lower it on apps that cache per request: warm-up fills those caches and the baseline then measures the warm-up, not the app. The run says so when it happens |
 | `--max-old-space <mb>` | 512 | Heap cap of each measured process. Raise it for apps whose legitimate working set is larger, or they die under measurement |
 | `--quick` | off | Fast preset (2000 requests × 4 cycles, 8s idle) — the exact profile the real-app validation ran with. Same cycle count as the default; what it trades away is traffic per cycle, so it sits on the noise floor and is less sensitive to slow leaks. Explicit flags override it |
 | `--no-resolve` | off | Skip the second pass on inconclusive routes |
 | `--diff-all` | off | Diff snapshots for stable routes too |
 | `--output <dir>` | `<app>/.next-leak` | Where runs are written |
+| `--write-config` | off | Write `next-leak.config.json` for the routes that need sample params, then exit. Never overwrites an existing file |
+
+There is a second command for the other half of the problem:
+
+```bash
+# Measure the build itself, not a built server
+npx next-leak build .
+```
+
+A large site can run out of heap while prerendering, before any server exists to
+measure ([#97464](https://github.com/vercel/next.js/issues/97464)). That command
+runs your build unmodified and samples the resident memory of each
+static-generation worker. It needs neither a previous build nor standalone
+output, and takes `--output` only.
 
 Dynamic routes need sample params in `next-leak.config.json` in your app dir:
 
@@ -116,6 +143,13 @@ Dynamic routes need sample params in `next-leak.config.json` in your app dir:
   "routes": { "/products/[id]": { "id": "42" } },
   "headers": { "accept-encoding": "gzip, br", "cookie": "session=..." }
 }
+```
+
+`--write-config` generates that file for you, filling in values from paths your
+build already prerendered where it knows them, so it usually resolves on the
+first try. When a run skips a route it prints the same fragment.
+
+```json
 ```
 
 - **`headers`** are sent with every request. Real traffic is not header-less:
@@ -168,7 +202,7 @@ separates them, because each one has a different fix:
   with the traffic, so the longer run decides the same thing. If the heap is
   flat but RSS keeps climbing, the report says so explicitly: that is an
   allocator, external-buffer or fragmentation problem, not a JS-heap leak.
-- **`leak`** — the report names the culprit when attribution resolves: your file (`culprit: src/app/x/page.tsx (your code)`), a dependency (package name), or framework internals. An `ISSUE-<route>.md` draft is generated; if the leak is app-owned, the draft tells you **not** to file it upstream.
+- **`leak`** — the report names the culprit when attribution resolves: your file (`culprit: src/app/x/page.tsx (your code)`), a dependency (package name), or framework internals. An `ISSUE-<route>.md` draft is generated **when the evidence plainly supports the verdict** — a `leak` carrying low-confidence warnings (growth barely over the threshold, one cycle dominating the mean, too few cycles for its size) gets the verdict but no draft, because a draft is written to be pasted into someone else's tracker. If the leak is app-owned, the draft tells you **not** to file it upstream.
 - **`inconclusive`** — the evidence does not decide. The run does not stop there: any inconclusive route is **measured again automatically**, with twice the cycles, and the second pass is what you see (`resolved at 8 cycles` next to the verdict). On the reproduction for [#95094](https://github.com/vercel/next.js/issues/95094), `--quick` alone reports `inconclusive` on three deltas and then comes back with the leak. `--no-resolve` turns the second pass off; when even that is undecided, the re-run command is still printed.
 - **`failed`** — the route errored under load (auth redirects, POST-only endpoints). >1% non-2xx aborts measurement instead of measuring garbage. That's by design.
 
@@ -198,6 +232,49 @@ value *sampled* (every 250 ms), so it is a lower bound.
 If the measured process dies at the limit instead of merely approaching it,
 the route fails saying exactly that, with the limit in force and how to raise
 it.
+
+### Memory a GC reclaims that production never reclaims
+
+There is a third question again, and it is the shape of most of the leaks
+reported in August: memory the process *holds between collections*, which a
+forced GC takes back and a long-running server may never run one to take back.
+Every verdict above is post-GC, so that class is invisible to it by
+construction.
+
+Each cycle is therefore read twice — once before any forced collection, once
+after — and the gap between them is reported when it is large:
+
+```
+✖ /posts/[slug]  leak  (+0.16 MB/1000 req)  heap 27.1 → 26.3 → … → 27.9 MB
+    driven through ISR revalidation (revalidates every 3600s; without it the load
+    would serve the cache)
+    ▲ unreclaimed: held 4.72 MB of arrayBuffers between collections that a GC took
+      back (4.7x what it retains) — a forced GC reclaims this, a long-running
+      process may not run one often enough to
+```
+
+A real measurement of the reproduction in
+[#96533](https://github.com/vercel/next.js/issues/96533), whose reporter
+accumulated 1.16 GB of `arrayBuffers` over four days against a flat JS heap.
+The note fires on the **gap**, not on a trend: that pre-collection series
+oscillates rather than climbs, and a rule keyed on it climbing reported nothing
+at all. It needs both a floor (2 MB) and a ratio (0.35× what the route retains),
+because the absolute size alone does not separate this from an ordinary leak.
+
+Its limit, stated on the line itself: the reading is taken seconds after load,
+not the hours a production process runs between full collections, so it
+includes memory that had not been collected yet. It never changes the verdict.
+
+### ISR routes are driven, not served from cache
+
+A route with a revalidation period serves its cache unless the request carries
+the build's own `x-prerender-revalidate` header. Measured on that same app: the
+identical run reports `leak` with the header and `stable` without it. next-leak
+reads `previewModeId` from `.next/prerender-manifest.json` and drives those
+routes itself; a header you set in `next-leak.config.json` wins untouched. When
+the manifest cannot supply one, the route is reported `not exercised` with no
+verdict, because a flat curve measured against a static cache says nothing about
+the app.
 
 ## The tool grades its own measurement
 
@@ -280,7 +357,7 @@ through the build's source maps.
   reporting a number that would be measuring the parent.
 - **Architectures:** verified on **arm64 and x64** (linux/amd64 in Docker) — same app, same parameters, same verdicts.
 - **Attribution** (naming the file) needs a Turbopack build with server sourcemaps — the Next 15+ default. On webpack builds the registry is empty by design and findings degrade to `unattributed` with raw retainer chains; measurement itself does not depend on it. Note that `output: "standalone"` + `--webpack` produced a bundle that could not start at all on `16.3.0-canary.90` (missing `@swc/helpers`), independently of this tool.
-- Empirically validated on Next **15.5.4, 16.0.x, 16.1.5, 16.2.x and 16.3-canary** (incl. Sentry, OpenTelemetry, PPR and i18n apps), against real reproductions from open issues. The contracts it relies on are stable since Next 13–14, but older versions are untested.
+- Empirically validated on Next **15.5.4, 16.0.x, 16.1.5, 16.2.x, 16.3.0/16.3.1 and 16.3-canary** (incl. Sentry, OpenTelemetry, PPR and i18n apps), against the public reproductions attached to real issues (open and since-fixed). Most recent measurements, 2026-08-17/18: the runtime path on 16.2.12 and 16.3.1-canary.18, the build path on 16.2.12 and 16.3.1. The contracts it relies on are stable since Next 13–14, but older versions are untested.
 - **Each measured process runs under a 512 MB heap cap** by default, so a leak
   reaches a ceiling in minutes instead of the hours a production container
   takes. An app whose legitimate working set is larger needs

--- a/README.md
+++ b/README.md
@@ -260,7 +260,15 @@ through the build's source maps.
 
 ## Scope and limits (read before filing issues)
 
-- **Supported:** App Router · `output: "standalone"` · Node ≥ 22 · Linux/macOS. Pages Router, non-standalone, and Windows are rejected with a clear message.
+- **Supported (default command):** App Router · `output: "standalone"` · Node ≥ 22 · Linux/macOS. Pages Router, non-standalone, and Windows are rejected with a clear message.
+- **`next-leak build <dir>`** measures the build instead of the server, and needs
+  neither a previous build nor standalone output — it runs `next build` and
+  samples the resident memory of each static-generation worker, which is where
+  large sites run out of heap while prerendering
+  ([#97464](https://github.com/vercel/next.js/issues/97464)). It does not apply
+  to projects using `experimental.workerThreads: true`: a worker thread has no
+  resident memory of its own to sample, and the run says so instead of
+  reporting a number that would be measuring the parent.
 - **Architectures:** verified on **arm64 and x64** (linux/amd64 in Docker) — same app, same parameters, same verdicts.
 - **Attribution** (naming the file) needs a Turbopack build with server sourcemaps — the Next 15+ default. On webpack builds the registry is empty by design and findings degrade to `unattributed` with raw retainer chains; measurement itself does not depend on it. Note that `output: "standalone"` + `--webpack` produced a bundle that could not start at all on `16.3.0-canary.90` (missing `@swc/helpers`), independently of this tool.
 - Empirically validated on Next **15.5.4, 16.0.x, 16.1.5, 16.2.x and 16.3-canary** (incl. Sentry, OpenTelemetry, PPR and i18n apps), against real reproductions from open issues. The contracts it relies on are stable since Next 13–14, but older versions are untested.

--- a/README.md
+++ b/README.md
@@ -261,6 +261,15 @@ through the build's source maps.
 ## Scope and limits (read before filing issues)
 
 - **Supported (default command):** App Router · `output: "standalone"` · Node ≥ 22 · Linux/macOS. Pages Router, non-standalone, and Windows are rejected with a clear message.
+- **Sample values can vary per request.** `"slug": "post-{n}"` gives every
+  request its own URL — the shape of bot traffic and of a cache that never
+  repeats a key. `"slug": "post-{n%200}"` cycles through exactly 200 distinct
+  values, revisiting them across cycles, which is the shape the reported leaks
+  actually have ([#96533](https://github.com/vercel/next.js/issues/96533)
+  revalidates a fixed set of posts;
+  [#92287](https://github.com/vercel/next.js/issues/92287) turns on how many
+  keys a cache holds at once). A value carrying both markers is rejected before
+  the run starts.
 - **`next-leak build <dir>`** measures the build instead of the server, and needs
   neither a previous build nor standalone output — it runs `next build` and
   samples the resident memory of each static-generation worker, which is where

--- a/src/build-report.test.ts
+++ b/src/build-report.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import { formatBuildReport } from "./build-report.js";
+import type { BuildRunResult } from "./build-run.js";
+
+const MB = 1024 * 1024;
+
+const baseResult: BuildRunResult = {
+  appDir: "/apps/docs",
+  status: "measured",
+  samplingFailure: null,
+  verdict: "leak",
+  trend: { verdict: "leak", growthPerCycle: 315 * MB, deltas: [], source: "heap" },
+  levels: [1070, 1400, 1930, 2380, 2700, 2960].map((value) => value * MB),
+  workers: [{ pid: 97155, samples: [] }],
+  parentSamples: [],
+  peakWorkerRssBytes: 2960 * MB,
+  netGrowthBytes: 1560 * MB,
+  pagesGenerated: 1700,
+  retentionPerPageBytes: 0.97 * MB,
+  heapExhausted: true,
+  strippedCapWarning: null,
+  exitCode: 1,
+  output: "",
+};
+
+describe("formatBuildReport", () => {
+  it("leads with the verdict and the curve it came from", () => {
+    const output = formatBuildReport(baseResult);
+
+    expect(output).toContain("static-generation worker  leak");
+    expect(output).toContain("worker rss 1070.0 MB → 1400.0 MB");
+  });
+
+  it("states retention per page, which is the number that predicts a bigger site", () => {
+    expect(formatBuildReport(baseResult)).toContain("0.97 MB/page over 1700 pages");
+  });
+
+  it("omits the per-page figure rather than inventing a denominator", () => {
+    const output = formatBuildReport({
+      ...baseResult,
+      pagesGenerated: null,
+      retentionPerPageBytes: null,
+    });
+
+    expect(output).toContain("grew 1560.0 MB");
+    expect(output).not.toContain("/page");
+  });
+
+  it("reports heap exhaustion as the finding, with what it reached", () => {
+    const output = formatBuildReport(baseResult);
+
+    expect(output).toContain("ran out of heap");
+    expect(output).toContain("2960.0 MB");
+    expect(output).toContain("1700 pages");
+    expect(output).toContain("no per-page figure for a crashed build");
+    expect(output).toContain("raising the cap moves the wall");
+  });
+
+  it("calls the memory resident, never retained heap", () => {
+    // No forced collection stands behind these samples, so the wording must
+    // not borrow the precision the runtime numbers have.
+    const output = formatBuildReport(baseResult);
+
+    expect(output).toContain("worker rss");
+    expect(output).not.toContain("retained heap");
+  });
+
+  it("makes no memory claim when the build failed for another reason", () => {
+    const output = formatBuildReport({
+      ...baseResult,
+      status: "build-failed",
+      verdict: null,
+      trend: null,
+      levels: [],
+      heapExhausted: false,
+      output: "Type error: Property 'x' does not exist",
+    });
+
+    expect(output).toContain("not memory");
+    expect(output).toContain("no memory claim is made");
+    expect(output).toContain("Type error");
+    expect(output).not.toContain("worker  leak");
+    expect(output).not.toContain("worker rss");
+  });
+
+  it("says plainly when there was nothing to measure", () => {
+    const output = formatBuildReport({
+      ...baseResult,
+      status: "nothing-to-measure",
+      verdict: null,
+      levels: [],
+      workers: [],
+    });
+
+    expect(output).toContain("no static-generation worker ran");
+  });
+
+  it("does not let a short build read as healthy", () => {
+    const output = formatBuildReport({
+      ...baseResult,
+      verdict: "inconclusive",
+      levels: [],
+      netGrowthBytes: 0,
+      heapExhausted: false,
+    });
+
+    expect(output).toContain("too short to judge");
+    expect(output).toContain("not a sign of health");
+  });
+
+  it("surfaces the stripped heap cap above everything else", () => {
+    const output = formatBuildReport({
+      ...baseResult,
+      strippedCapWarning: "NODE_OPTIONS sets --max-old-space-size=2048, which Next strips",
+      });
+
+    expect(output.split("\n").slice(0, 4).join("\n")).toContain("Next strips");
+  });
+
+  it("says how many workers ran when more than one did", () => {
+    const output = formatBuildReport({
+      ...baseResult,
+      workers: [
+        { pid: 1, samples: [] },
+        { pid: 2, samples: [] },
+      ],
+    });
+
+    expect(output).toContain("2 workers ran");
+    expect(output).toContain("worst of them");
+  });
+});
+
+// An unreadable process table and a build with no workers look identical from
+// the sampler's side, and only one of them is good news.
+describe("formatBuildReport when the table cannot be read", () => {
+  it("says it could not look, not that there was nothing to see", () => {
+    const output = formatBuildReport({
+      ...baseResult,
+      status: "cannot-sample",
+      samplingFailure: "spawn ps EPERM",
+      verdict: null,
+      trend: null,
+      levels: [],
+      workers: [],
+    });
+
+    expect(output).toContain("could not read the process table");
+    expect(output).toContain("spawn ps EPERM");
+    expect(output).toContain("not a clean run");
+    expect(output).not.toContain("nothing to measure");
+  });
+});

--- a/src/build-report.ts
+++ b/src/build-report.ts
@@ -1,0 +1,109 @@
+import type { BuildRunResult } from "./build-run.js";
+
+const MB = 1024 * 1024;
+
+const mb = (bytes: number): string => `${(bytes / MB).toFixed(1)} MB`;
+
+/**
+ * Per-page retention is a small number that carries the whole finding — the
+ * difference between 0.97 and 1.0 MB per page is 75 MB over a 2500-page site,
+ * so it gets a decimal place the gigabyte-scale figures do not need.
+ */
+const mbPrecise = (bytes: number): string => `${(bytes / MB).toFixed(2)} MB`;
+
+const VERDICT_ICON: Record<string, string> = {
+  leak: "✖",
+  stable: "✔",
+  inconclusive: "?",
+};
+
+function curveLine(levels: readonly number[]): string {
+  return levels.map((level) => mb(level)).join(" → ");
+}
+
+function growthLine(result: BuildRunResult): string {
+  const perPage =
+    result.retentionPerPageBytes === null
+      ? ""
+      : `  (${mbPrecise(result.retentionPerPageBytes)}/page over ${result.pagesGenerated} pages)`;
+  return `      grew ${mb(result.netGrowthBytes)} across the generation phase${perPage}`;
+}
+
+/**
+ * Renders the build report.
+ *
+ * Says "worker rss" everywhere rather than "heap" or "retained": these samples
+ * are resident memory with no forced collection behind them, and calling them
+ * retention would borrow a precision the measurement does not have. RSS is
+ * still the honest axis here — it is what a CI runner's limit is enforced
+ * against and what the OOM killer reads.
+ */
+export function formatBuildReport(result: BuildRunResult): string {
+  const lines: string[] = [`next-leak build · ${result.appDir}`, ""];
+
+  if (result.strippedCapWarning !== null) {
+    lines.push(`  ▲ ${result.strippedCapWarning}`, "");
+  }
+
+  if (result.status === "build-failed") {
+    lines.push(
+      `  ✖ the build failed for a reason that is not memory (exit ${result.exitCode ?? "?"})`,
+      `      no memory claim is made; the build's own output follows`,
+      "",
+      ...result.output.trimEnd().split("\n").slice(-20).map((line) => `      ${line}`)
+    );
+    return lines.join("\n");
+  }
+
+  if (result.status === "cannot-sample") {
+    lines.push(
+      `  ✖ could not read the process table, so the build was not measured`,
+      `      ${result.samplingFailure ?? "unknown reason"}`,
+      `      this is not a clean run: an unreadable table and a build with no`,
+      `      workers look identical from here, and only one of them is good news`
+    );
+    return lines.join("\n");
+  }
+
+  if (result.status === "nothing-to-measure") {
+    lines.push(
+      `  – no static-generation worker ran, so there was nothing to measure`,
+      `      a build with no prerendered pages does not exercise this path`
+    );
+    return lines.join("\n");
+  }
+
+  const verdict = result.verdict ?? "inconclusive";
+  const icon = VERDICT_ICON[verdict] ?? "?";
+  lines.push(`  ${icon} static-generation worker  ${verdict}`);
+
+  if (result.levels.length > 0) {
+    lines.push(`      worker rss ${curveLine(result.levels)}`);
+  }
+  if (result.netGrowthBytes > 0) {
+    lines.push(growthLine(result));
+  }
+  if (verdict === "inconclusive" && result.levels.length === 0) {
+    lines.push(`      the build was too short to judge — not a sign of health`);
+  }
+  if (result.heapExhausted) {
+    lines.push(
+      `      the worker ran out of heap and the build died with it after ` +
+        `${result.pagesGenerated ?? "?"} pages, reaching ${mb(result.peakWorkerRssBytes)}`,
+      `      no per-page figure for a crashed build: the curve is truncated where`,
+      `      the worker died, so any denominator would be guesswork`,
+      `      that outcome is the verdict here, whatever shape the curve above has:`,
+      `      raising the cap moves the wall; it does not remove it`
+    );
+  }
+  if (result.workers.length > 1) {
+    lines.push(`      ${result.workers.length} workers ran; the verdict is the worst of them`);
+  }
+
+  lines.push(
+    "",
+    `  peak worker rss ${mb(result.peakWorkerRssBytes)} · sampled from the process tree, so a`,
+    `  spike shorter than the polling interval is not observed`
+  );
+  return lines.join("\n");
+}

--- a/src/build-run.test.ts
+++ b/src/build-run.test.ts
@@ -1,0 +1,309 @@
+import { EventEmitter } from "node:events";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { runBuildMeasurement, type BuildRunDeps } from "./build-run.js";
+import { parseProcessTable, type ProcessTableSample } from "./process-tree.js";
+
+const MB = 1024 * 1024;
+const BUILD_PID = 4242;
+const WORKER_PID = 4243;
+const WORKER_COMMAND = "/bin/node /repo/node_modules/next/dist/compiled/jest-worker/processChild.js";
+
+async function makeProject(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "next-leak-build-run-"));
+  await writeFile(
+    path.join(dir, "package.json"),
+    JSON.stringify({ dependencies: { next: "16.3.1" }, scripts: { build: "next build" } })
+  );
+  return dir;
+}
+
+type FakeChild = EventEmitter & {
+  pid: number;
+  stdout: Readable;
+  stderr: Readable;
+  kill: (signal?: string) => boolean;
+};
+
+/**
+ * A fake `next build`. It does not exit on its own: the scripted process table
+ * ends it once every sample has been served, so the polling loop sees the whole
+ * curve instead of racing the exit.
+ */
+function fakeChild(output: string): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.pid = BUILD_PID;
+  child.stdout = Readable.from([output]);
+  child.stderr = Readable.from([]);
+  child.kill = () => true;
+  return child;
+}
+
+/**
+ * Drives the run with a scripted process table: one row per poll, so the
+ * worker's RSS follows `workerMb` exactly.
+ */
+function makeDeps(
+  workerMb: number[],
+  options: {
+    output?: string;
+    exitCode?: number | null;
+    parentMb?: number[];
+    noWorker?: boolean;
+  } = {}
+): BuildRunDeps {
+  let poll = 0;
+  let clock = 0;
+  let child: FakeChild | undefined;
+  const exitCode = options.exitCode === undefined ? 0 : options.exitCode;
+  return {
+    spawnBuild: () => {
+      child = fakeChild(options.output ?? "");
+      return child as never;
+    },
+    sampleTable: async (): Promise<ProcessTableSample> => {
+      if (poll >= workerMb.length) {
+        setImmediate(() => child?.emit("exit", exitCode));
+        return { ok: true, rows: [] };
+      }
+      const workerRss = workerMb[poll] ?? 0;
+      const parentRss = options.parentMb?.[Math.min(poll, (options.parentMb?.length ?? 1) - 1)] ?? 300;
+      poll += 1;
+      const parentRow = `${BUILD_PID} 1 ${parentRss * 1024} next-build\n`;
+      return {
+        ok: true,
+        rows: parseProcessTable(
+          options.noWorker === true
+            ? parentRow
+            : `${parentRow}${WORKER_PID} ${BUILD_PID} ${workerRss * 1024} ${WORKER_COMMAND}\n`
+        ),
+      };
+    },
+    now: () => {
+      clock += 500;
+      return clock;
+    },
+    sleep: async () => {
+      // Without a turn of the event loop the exit event never lands and the
+      // polling loop would spin forever.
+      await new Promise((resolve) => setImmediate(resolve));
+    },
+  };
+}
+
+describe("runBuildMeasurement", () => {
+  it("calls a worker that climbs across the build a leak", async () => {
+    // The 16.3.1 shape from the #97464 reproduction, in MB.
+    const appDir = await makeProject();
+    const result = await runBuildMeasurement(
+      { appDir },
+      makeDeps([1070, 1400, 1930, 2380, 2550, 2700, 2960, 2960])
+    );
+
+    expect(result.status).toBe("measured");
+    expect(result.verdict).toBe("leak");
+    expect(result.workers).toHaveLength(1);
+  });
+
+  it("calls the 16.2.12 control stable", async () => {
+    const appDir = await makeProject();
+    const result = await runBuildMeasurement(
+      { appDir },
+      makeDeps([428, 500, 512, 507, 524, 519, 529, 529])
+    );
+
+    expect(result.verdict).toBe("stable");
+  });
+
+  it("judges the worker, not the parent that sheds while it climbs", async () => {
+    // Summing the tree would cancel the finding out: in the real run the
+    // parent fell from 1.43 GB to 0.10 GB while the worker climbed.
+    const appDir = await makeProject();
+    const result = await runBuildMeasurement(
+      { appDir },
+      makeDeps([1070, 1400, 1930, 2380, 2550, 2700, 2960, 2960], {
+        parentMb: [1430, 1200, 830, 500, 330, 200, 100, 100],
+      })
+    );
+
+    expect(result.verdict).toBe("leak");
+    expect(result.parentSamples.length).toBeGreaterThan(0);
+  });
+
+  it("reports a worker killed by the heap limit as the finding, not a failure", async () => {
+    const appDir = await makeProject();
+    const output = [
+      "Generating static pages (1700/2504)",
+      "FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory",
+      "⨯ Next.js build worker exited with code: null and signal: SIGABRT",
+    ].join("\n");
+    const result = await runBuildMeasurement(
+      { appDir },
+      makeDeps([1070, 1400, 1930, 2380, 2550, 2700, 2960, 2960], { output, exitCode: 1 })
+    );
+
+    expect(result.status).toBe("measured");
+    expect(result.heapExhausted).toBe(true);
+    expect(result.verdict).toBe("leak");
+  });
+
+  it("makes no memory claim when the build breaks for another reason", async () => {
+    const appDir = await makeProject();
+    const result = await runBuildMeasurement(
+      { appDir },
+      makeDeps([400, 400], { output: "Type error: Property 'x' does not exist", exitCode: 1 })
+    );
+
+    expect(result.status).toBe("build-failed");
+    expect(result.verdict).toBeNull();
+  });
+
+  it("says there was nothing to measure when no worker ever ran", async () => {
+    const appDir = await makeProject();
+    const result = await runBuildMeasurement(
+      { appDir },
+      makeDeps([300, 300, 300], { noWorker: true })
+    );
+
+    expect(result.status).toBe("nothing-to-measure");
+    expect(result.verdict).toBeNull();
+    expect(result.parentSamples.length).toBeGreaterThan(0);
+  });
+
+  it("reports retention per page when the build says how far it got", async () => {
+    const appDir = await makeProject();
+    const result = await runBuildMeasurement(
+      { appDir },
+      makeDeps([1070, 1400, 1930, 2380, 2550, 2700, 2960, 2960], {
+        output: "Generating static pages (1700/2504)",
+      })
+    );
+
+    expect(result.pagesGenerated).toBe(1700);
+    expect(result.retentionPerPageBytes).not.toBeNull();
+    expect((result.retentionPerPageBytes ?? 0) / MB).toBeGreaterThan(0.5);
+  });
+
+  it("omits per-page retention when the build never said", async () => {
+    const appDir = await makeProject();
+    const result = await runBuildMeasurement(
+      { appDir },
+      makeDeps([1070, 1400, 1930, 2380, 2550, 2700, 2960, 2960])
+    );
+
+    expect(result.pagesGenerated).toBeNull();
+    expect(result.retentionPerPageBytes).toBeNull();
+  });
+
+  it("warns about a heap cap Next strips before the worker sees it", async () => {
+    const appDir = await makeProject();
+    const messages: string[] = [];
+    const result = await runBuildMeasurement(
+      {
+        appDir,
+        env: { NODE_OPTIONS: "--max-old-space-size=2048" },
+        onProgress: (message) => messages.push(message),
+      },
+      makeDeps([400, 420, 410, 430, 425, 440, 435, 435])
+    );
+
+    expect(result.strippedCapWarning).toContain("--max-heap-size=2048");
+    expect(messages.some((message) => message.includes("never sees it"))).toBe(true);
+  });
+
+  it("keeps the peak the worker reached", async () => {
+    const appDir = await makeProject();
+    const result = await runBuildMeasurement(
+      { appDir },
+      makeDeps([1070, 1400, 1930, 2380, 2550, 2700, 2960, 2960])
+    );
+
+    expect(result.peakWorkerRssBytes).toBe(2960 * MB);
+  });
+
+  it("refuses a project that is not a Next.js app before spawning anything", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "next-leak-build-run-"));
+    await writeFile(path.join(dir, "package.json"), JSON.stringify({ dependencies: {} }));
+
+    await expect(
+      runBuildMeasurement({ appDir: dir }, makeDeps([100, 200]))
+    ).rejects.toThrow(/not a Next\.js project/);
+  });
+});
+
+describe("runBuildMeasurement when the process table is unreadable", () => {
+  it("reports that it could not look instead of finding nothing", async () => {
+    // Seen for real: a sandbox denying `ps` turned a leaking build into a
+    // clean "nothing to measure" run.
+    const appDir = await makeProject();
+    const deps = makeDeps([400, 400, 400]);
+    let child: { emit: (event: string, code: number) => void } | undefined;
+    const result = await runBuildMeasurement(
+      { appDir },
+      {
+        ...deps,
+        spawnBuild: (...args) => {
+          const spawned = deps.spawnBuild(...args);
+          child = spawned as unknown as typeof child;
+          return spawned;
+        },
+        sampleTable: async () => {
+          // The build itself carries on and finishes; only the sampling died.
+          setImmediate(() => child?.emit("exit", 0));
+          return { ok: false, reason: "spawn ps EPERM" };
+        },
+      }
+    );
+
+    expect(result.status).toBe("cannot-sample");
+    expect(result.samplingFailure).toBe("spawn ps EPERM");
+    expect(result.verdict).toBeNull();
+  });
+});
+
+// A build that ran out of heap is not a curve to be interpreted. Measured on
+// the real #97464 repro: the worker died at 1758 MB after 1252 pages, and the
+// segmented curve read `stable` because one segment gave 79 MB back.
+describe("runBuildMeasurement when the worker runs out of heap", () => {
+  it("calls it a leak even when the curve oscillates enough to look stable", async () => {
+    const appDir = await makeProject();
+    const output = [
+      "Generating static pages (1252/2504)",
+      "FATAL ERROR: JavaScript heap out of memory",
+    ].join("\n");
+    const result = await runBuildMeasurement(
+      { appDir },
+      makeDeps([1252, 1135, 1255, 1732, 1654, 1685, 1758, 1758], { output, exitCode: 1 })
+    );
+
+    expect(result.heapExhausted).toBe(true);
+    expect(result.verdict).toBe("leak");
+    // The measured trend is still reported as it was read: the override is a
+    // statement about the outcome, not a rewrite of the evidence.
+    expect(result.trend?.verdict).toBe("stable");
+  });
+});
+
+describe("per-page retention when the build crashed", () => {
+  it("reports no per-page figure, because the curve is truncated", async () => {
+    // Measured against the real reproduction: the segmented curve ends below
+    // where it started, and using the worker's first raw reading as the base
+    // folds module loading into the numerator — that gave 1.59 MB/page against
+    // the ~0.9 the issue measures. How far it got and what it reached are the
+    // facts; a denominator here would be guesswork.
+    const appDir = await makeProject();
+    const output = ["Generating static pages (1252/2504)", "FATAL ERROR: JavaScript heap out of memory"].join("\n");
+    const result = await runBuildMeasurement(
+      { appDir },
+      makeDeps([1381, 1974, 2245, 2479, 1552, 1533, 1688, 1688], { output, exitCode: 1 })
+    );
+
+    expect(result.verdict).toBe("leak");
+    expect(result.pagesGenerated).toBe(1252);
+    expect(result.peakWorkerRssBytes).toBe(2479 * MB);
+    expect(result.retentionPerPageBytes).toBeNull();
+  });
+});

--- a/src/build-run.ts
+++ b/src/build-run.ts
@@ -1,0 +1,285 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { validateBuildTarget } from "./build-target.js";
+import {
+  classifyBuildSamples,
+  diedOfHeapExhaustion,
+  netGrowthOf,
+  pagesGeneratedFrom,
+  retentionPerPage,
+  strippedHeapCap,
+  type BuildSample,
+} from "./build-verdict.js";
+import { registerChild, unregisterChild } from "./launcher.js";
+import {
+  descendantsOf,
+  isStaticGenWorker,
+  sampleProcessTable,
+  type ProcessRow,
+  type ProcessTableSample,
+} from "./process-tree.js";
+import type { TrendResult } from "./trend.js";
+
+/** How often the process tree is sampled while the build runs. */
+const POLL_MS = 500;
+
+export type WorkerSeries = {
+  pid: number;
+  samples: BuildSample[];
+};
+
+export type BuildRunResult = {
+  appDir: string;
+  /**
+   * `measured` carries a verdict. `build-failed` means the build broke for a
+   * reason that is not memory, and makes no memory claim. `nothing-to-measure`
+   * means no static-generation worker ever ran. `cannot-sample` means the
+   * process table could not be read, which is not the same as finding nothing
+   * in it.
+   */
+  status: "measured" | "build-failed" | "nothing-to-measure" | "cannot-sample";
+  /** Why sampling stopped, when it did. */
+  samplingFailure: string | null;
+  verdict: TrendResult["verdict"] | null;
+  trend: TrendResult | null;
+  /** Segmented levels the verdict was read from, in bytes. */
+  levels: number[];
+  workers: WorkerSeries[];
+  /** The build's own process, reported but never judged: it sheds while workers climb. */
+  parentSamples: BuildSample[];
+  peakWorkerRssBytes: number;
+  netGrowthBytes: number;
+  pagesGenerated: number | null;
+  retentionPerPageBytes: number | null;
+  /** True when a worker hit the V8 heap limit — the finding, not a failure. */
+  heapExhausted: boolean;
+  strippedCapWarning: string | null;
+  exitCode: number | null;
+  output: string;
+};
+
+export type BuildRunOptions = {
+  appDir: string;
+  signal?: AbortSignal;
+  onProgress?: (message: string) => void;
+  /** Overrides `process.env` for the build. */
+  env?: NodeJS.ProcessEnv;
+};
+
+export type BuildRunDeps = {
+  spawnBuild: (appDir: string, env: NodeJS.ProcessEnv) => ChildProcess;
+  sampleTable: () => Promise<ProcessTableSample>;
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+};
+
+/**
+ * Runs Next's own binary rather than `npm run build`.
+ *
+ * A package-manager wrapper adds two processes between the run and the build
+ * for nothing, and it makes the tree depend on which manager the project uses.
+ * Going straight at the bin keeps the tree short and the same everywhere.
+ */
+function spawnNextBuild(appDir: string, env: NodeJS.ProcessEnv): ChildProcess {
+  const nextBin = path.join(appDir, "node_modules", "next", "dist", "bin", "next");
+  return spawn(process.execPath, [nextBin, "build"], {
+    cwd: appDir,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+const defaultDeps: BuildRunDeps = {
+  spawnBuild: spawnNextBuild,
+  sampleTable: sampleProcessTable,
+  now: () => Date.now(),
+  sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+};
+
+/** Collects one poll's readings into the per-PID series. */
+function recordSample(
+  rows: readonly ProcessRow[],
+  rootPid: number,
+  atMs: number,
+  workers: Map<number, BuildSample[]>,
+  parentSamples: BuildSample[]
+): void {
+  const root = rows.find((row) => row.pid === rootPid);
+  if (root !== undefined) {
+    parentSamples.push({ atMs, rssBytes: root.rssBytes });
+  }
+  for (const row of descendantsOf(rows, rootPid)) {
+    if (!isStaticGenWorker(row)) {
+      continue;
+    }
+    const series = workers.get(row.pid) ?? [];
+    series.push({ atMs, rssBytes: row.rssBytes });
+    workers.set(row.pid, series);
+  }
+}
+
+/** The worker that grew the most: a verdict from the average would hide it. */
+function worstWorker(workers: readonly WorkerSeries[]): WorkerSeries | null {
+  let worst: WorkerSeries | null = null;
+  let worstGrowth = -Infinity;
+  for (const worker of workers) {
+    const growth = netGrowthOf(classifyBuildSamples(worker.samples).levels);
+    if (growth > worstGrowth) {
+      worstGrowth = growth;
+      worst = worker;
+    }
+  }
+  return worst;
+}
+
+const peakOf = (samples: readonly BuildSample[]): number =>
+  samples.reduce((highest, sample) => Math.max(highest, sample.rssBytes), 0);
+
+/**
+ * Measures the memory of a `next build`'s static-generation workers.
+ *
+ * The build runs unmodified — nothing is injected into it. Workers are child
+ * processes with their own resident memory, so the whole measurement is made
+ * from outside by watching the process tree.
+ */
+export async function runBuildMeasurement(
+  options: BuildRunOptions,
+  deps: BuildRunDeps = defaultDeps
+): Promise<BuildRunResult> {
+  const target = await validateBuildTarget(options.appDir);
+  const progress = options.onProgress ?? ((): void => {});
+  const env = options.env ?? process.env;
+  const strippedCapWarning = strippedHeapCap(env["NODE_OPTIONS"]);
+  if (strippedCapWarning !== null) {
+    progress(strippedCapWarning);
+  }
+
+  progress(`building ${target.appDir}`);
+  const child = deps.spawnBuild(target.appDir, env);
+  registerChild(child);
+
+  let output = "";
+  const capture = (chunk: Buffer | string): void => {
+    output += String(chunk);
+  };
+  child.stdout?.on("data", capture);
+  child.stderr?.on("data", capture);
+
+  const startedAt = deps.now();
+  const workerSamples = new Map<number, BuildSample[]>();
+  const parentSamples: BuildSample[] = [];
+  let finished = false;
+  const exit = new Promise<number | null>((resolve) => {
+    child.once("exit", (code) => {
+      finished = true;
+      resolve(code);
+    });
+  });
+
+  const abort = (): void => {
+    child.kill("SIGTERM");
+  };
+  options.signal?.addEventListener("abort", abort, { once: true });
+
+  let samplingFailure: string | null = null;
+  const polling = (async (): Promise<void> => {
+    while (!finished) {
+      await deps.sleep(POLL_MS);
+      if (finished || child.pid === undefined) {
+        return;
+      }
+      const sample = await deps.sampleTable();
+      if (!sample.ok) {
+        // Every later poll would fail the same way, and a run that cannot see
+        // the process table has no business reporting on it.
+        samplingFailure = sample.reason;
+        return;
+      }
+      recordSample(sample.rows, child.pid, deps.now() - startedAt, workerSamples, parentSamples);
+    }
+  })();
+
+  const exitCode = await exit;
+  await polling;
+  options.signal?.removeEventListener("abort", abort);
+  unregisterChild(child);
+
+  const workers: WorkerSeries[] = [...workerSamples].map(([pid, samples]) => ({ pid, samples }));
+  const heapExhausted = diedOfHeapExhaustion(output);
+  const pagesGenerated = pagesGeneratedFrom(output);
+
+  if (workers.length === 0) {
+    return {
+      appDir: target.appDir,
+      // "Could not look" is not "nothing was there". A build that broke before
+      // generating anything is a failed build, not a measurement of nothing.
+      status:
+        samplingFailure !== null
+          ? "cannot-sample"
+          : exitCode === 0
+            ? "nothing-to-measure"
+            : "build-failed",
+      samplingFailure,
+      verdict: null,
+      trend: null,
+      levels: [],
+      workers,
+      parentSamples,
+      peakWorkerRssBytes: 0,
+      netGrowthBytes: 0,
+      pagesGenerated,
+      retentionPerPageBytes: null,
+      heapExhausted,
+      strippedCapWarning,
+      exitCode,
+      output,
+    };
+  }
+
+  const worst = worstWorker(workers);
+  const { trend, levels } = classifyBuildSamples(worst?.samples ?? []);
+  const peakWorkerRssBytes = workers.reduce(
+    (highest, worker) => Math.max(highest, peakOf(worker.samples)),
+    0
+  );
+  // A worker killed by the heap limit is the finding: the run measured exactly
+  // what it set out to, and the build failing is the symptom. A build that
+  // broke for any other reason stopped the measurement partway, so its curve
+  // supports no claim — the samples are still reported as evidence.
+  const measured = exitCode === 0 || heapExhausted;
+  // Running out of heap is not a shape to be inferred from, it is the outcome
+  // observed. Measured for real on the #97464 repro: the worker died at
+  // 1758 MB after 1252 pages and the segmented curve still read `stable`,
+  // because one segment gave 79 MB back. A curve cannot overrule a corpse.
+  const verdict = heapExhausted ? "leak" : trend.verdict;
+  // A worker that died mid-flight has no trustworthy per-page figure. Its
+  // segmented curve ends wherever the crash landed — on the real #97464 run,
+  // *below* where it started — and the only other base available, the worker's
+  // first raw reading, folds module loading and JIT into the numerator. Both
+  // were tried against the reproduction: one reported nothing, the other 1.59
+  // MB/page against the ~0.9 the issue measures from heapUsed. The honest
+  // report for a crashed build is how far it got and what it reached.
+  const growthBytes = heapExhausted ? 0 : netGrowthOf(levels);
+
+  return {
+    appDir: target.appDir,
+    status: measured ? "measured" : "build-failed",
+    samplingFailure,
+    verdict: measured ? verdict : null,
+    trend: measured ? trend : null,
+    levels: measured ? levels : [],
+    workers,
+    parentSamples,
+    peakWorkerRssBytes,
+    netGrowthBytes: measured ? growthBytes : 0,
+    pagesGenerated,
+    retentionPerPageBytes:
+      measured && growthBytes > 0 && pagesGenerated !== null && pagesGenerated > 0
+        ? growthBytes / pagesGenerated
+        : null,
+    heapExhausted,
+    strippedCapWarning,
+    exitCode,
+    output,
+  };
+}

--- a/src/build-target.test.ts
+++ b/src/build-target.test.ts
@@ -1,0 +1,70 @@
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { validateBuildTarget } from "./build-target.js";
+import { TargetError } from "./target.js";
+
+async function makeProject(files: Record<string, string>): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "next-leak-build-target-"));
+  for (const [name, content] of Object.entries(files)) {
+    await mkdir(path.dirname(path.join(dir, name)), { recursive: true });
+    await writeFile(path.join(dir, name), content);
+  }
+  return dir;
+}
+
+describe("validateBuildTarget", () => {
+  it("accepts a project that has never been built", async () => {
+    // Producing .next is the thing being measured: demanding it up front would
+    // reject exactly the builds that OOM before writing anything.
+    const dir = await makeProject({
+      "package.json": JSON.stringify({ dependencies: { next: "16.3.1" }, scripts: { build: "next build" } }),
+    });
+    const target = await validateBuildTarget(dir);
+
+    expect(target.appDir).toBe(path.resolve(dir));
+    expect(target.buildScript).toBe("build");
+  });
+
+  it("accepts a project identified only by its next.config", async () => {
+    const dir = await makeProject({ "next.config.mjs": "export default {}\n" });
+    await expect(validateBuildTarget(dir)).resolves.toBeDefined();
+  });
+
+  it("reports no build script rather than assuming one", async () => {
+    const dir = await makeProject({
+      "package.json": JSON.stringify({ dependencies: { next: "16.3.1" } }),
+    });
+    expect((await validateBuildTarget(dir)).buildScript).toBeNull();
+  });
+
+  it("rejects a directory that is not a Next.js project", async () => {
+    const dir = await makeProject({ "package.json": JSON.stringify({ dependencies: {} }) });
+    await expect(validateBuildTarget(dir)).rejects.toThrow(/not a Next\.js project/);
+  });
+
+  it("rejects a directory it cannot read", async () => {
+    await expect(validateBuildTarget("/nope/not/here")).rejects.toThrow(TargetError);
+  });
+
+  it("refuses worker threads, explaining why they cannot be sampled", async () => {
+    // A thread shares the parent's resident memory, so there is nothing
+    // per-worker to measure from outside.
+    const dir = await makeProject({
+      "package.json": JSON.stringify({ dependencies: { next: "16.3.1" } }),
+      "next.config.mjs": "export default { experimental: { workerThreads: true } }\n",
+    });
+
+    await expect(validateBuildTarget(dir)).rejects.toThrow(/workerThreads/);
+    await expect(validateBuildTarget(dir)).rejects.toThrow(/has none of its own/);
+  });
+
+  it("accepts a project that turns worker threads off explicitly", async () => {
+    const dir = await makeProject({
+      "package.json": JSON.stringify({ dependencies: { next: "16.3.1" } }),
+      "next.config.mjs": "export default { experimental: { workerThreads: false } }\n",
+    });
+    await expect(validateBuildTarget(dir)).resolves.toBeDefined();
+  });
+});

--- a/src/build-target.ts
+++ b/src/build-target.ts
@@ -1,0 +1,102 @@
+import { access, readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { TargetError } from "./target.js";
+
+export type ValidatedBuildTarget = {
+  appDir: string;
+  /** The package script to run, when one of the usual names exists. */
+  buildScript: string | null;
+};
+
+const CONFIG_NAMES = ["next.config.js", "next.config.mjs", "next.config.ts", "next.config.cjs"];
+
+async function exists(file: string): Promise<boolean> {
+  try {
+    await access(file);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+type PackageJson = {
+  scripts?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+};
+
+async function readPackageJson(appDir: string): Promise<PackageJson | null> {
+  try {
+    return JSON.parse(await readFile(path.join(appDir, "package.json"), "utf8")) as PackageJson;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether the project runs static generation in threads instead of processes.
+ *
+ * A worker thread shares the process's resident memory, so there is nothing
+ * per-worker to sample from outside — the approach this command is built on
+ * simply does not apply. Next defaults this to false; a project that turns it
+ * on gets told why the run cannot proceed rather than a number that would be
+ * measuring the wrong thing.
+ */
+async function usesWorkerThreads(appDir: string): Promise<boolean> {
+  for (const name of CONFIG_NAMES) {
+    const file = path.join(appDir, name);
+    if (!(await exists(file))) {
+      continue;
+    }
+    const source = await readFile(file, "utf8");
+    if (/workerThreads\s*:\s*true/.test(source)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Validates a target for a *build* measurement.
+ *
+ * Deliberately weaker than `validateTarget`: this command measures the build
+ * itself, so demanding `.next` or a standalone bundle would reject exactly the
+ * projects it exists to help — a build that OOMs never produces either.
+ */
+export async function validateBuildTarget(appDir: string): Promise<ValidatedBuildTarget> {
+  const resolved = path.resolve(appDir);
+  let entries: string[];
+  try {
+    entries = await readdir(resolved);
+  } catch {
+    throw new TargetError("NO_BUILD", `Cannot read ${resolved}.`);
+  }
+
+  const packageJson = await readPackageJson(resolved);
+  const dependencies = {
+    ...(packageJson?.dependencies ?? {}),
+    ...(packageJson?.devDependencies ?? {}),
+  };
+  const hasNext = "next" in dependencies || entries.some((entry) => CONFIG_NAMES.includes(entry));
+  if (!hasNext) {
+    throw new TargetError(
+      "NO_BUILD",
+      `${resolved} is not a Next.js project: no "next" dependency in package.json and no next.config.\n` +
+        `next-leak build measures a Next.js build. Point it at the directory holding your package.json.`
+    );
+  }
+
+  if (await usesWorkerThreads(resolved)) {
+    throw new TargetError(
+      "NO_BUILD",
+      `This project sets experimental.workerThreads: true.\n` +
+        `next-leak build measures the resident memory of each static-generation worker, and a\n` +
+        `worker thread has none of its own — it shares the parent's. Remove the flag (Next's\n` +
+        `default) to make the build measurable.`
+    );
+  }
+
+  const scripts = packageJson?.scripts ?? {};
+  const buildScript = "build" in scripts ? "build" : null;
+  return { appDir: resolved, buildScript };
+}

--- a/src/build-verdict.test.ts
+++ b/src/build-verdict.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  BUILD_SEGMENTS,
+  classifyBuildSamples,
+  diedOfHeapExhaustion,
+  netGrowthOf,
+  pagesGeneratedFrom,
+  retentionPerPage,
+  segmentSamples,
+  strippedHeapCap,
+  type BuildSample,
+} from "./build-verdict.js";
+
+const MB = 1024 * 1024;
+
+const rising = (values: number[]): BuildSample[] =>
+  values.map((mb, index) => ({ atMs: index * 1000, rssBytes: mb * MB }));
+
+describe("segmentSamples", () => {
+  it("takes the last reading of each equal slice", () => {
+    const samples = rising([100, 200, 300, 400]);
+    expect(segmentSamples(samples, 2)).toEqual([200 * MB, 400 * MB]);
+  });
+
+  it("keeps a climb a climb instead of averaging it flat", () => {
+    const levels = segmentSamples(rising([100, 150, 200, 250, 300, 350]), 3);
+    expect(levels).toEqual([150 * MB, 250 * MB, 350 * MB]);
+  });
+
+  it("returns nothing when every sample lands at the same instant", () => {
+    const samples: BuildSample[] = [
+      { atMs: 5, rssBytes: MB },
+      { atMs: 5, rssBytes: 2 * MB },
+    ];
+    expect(segmentSamples(samples, 4)).toEqual([]);
+  });
+
+  it("returns nothing for an empty window or no segments", () => {
+    expect(segmentSamples([], 4)).toEqual([]);
+    expect(segmentSamples(rising([1, 2]), 0)).toEqual([]);
+  });
+});
+
+describe("classifyBuildSamples", () => {
+  it("calls a worker that climbs every segment a leak", () => {
+    // The 16.3.1 shape: 1.07 GB to 2.96 GB across the generation phase.
+    const samples = rising([1070, 1400, 1930, 2380, 2550, 2700, 2960]);
+    const { trend } = classifyBuildSamples(samples);
+
+    expect(trend.verdict).toBe("leak");
+  });
+
+  it("calls a worker that holds its level stable", () => {
+    // The 16.2.12 control: same build, flat between 428 and 530 MB.
+    const samples = rising([428, 500, 512, 507, 524, 519, 529]);
+    expect(classifyBuildSamples(samples).trend.verdict).toBe("stable");
+  });
+
+  it("is undecided when the build was too short to fill its segments", () => {
+    // Better undecided than implying health from two readings.
+    const samples = rising([400, 900]);
+    expect(classifyBuildSamples(samples).trend.verdict).toBe("inconclusive");
+  });
+
+  it("reads the verdict from six segments", () => {
+    expect(BUILD_SEGMENTS).toBe(6);
+    const { levels } = classifyBuildSamples(rising([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]));
+    expect(levels).toHaveLength(6);
+  });
+});
+
+describe("retentionPerPage", () => {
+  it("reports the per-page figure the issue is quoted in", () => {
+    // 1600 pages between the first analyzed level and the last, ~0.97 MB each.
+    const levels = [1070 * MB, 1200 * MB, 1700 * MB, 2200 * MB, 2752 * MB];
+    const perPage = retentionPerPage(levels, 1600);
+
+    expect(perPage).not.toBeNull();
+    expect((perPage ?? 0) / MB).toBeCloseTo(0.97, 1);
+  });
+
+  it("invents no denominator when the page count is unknown", () => {
+    expect(retentionPerPage([100 * MB, 200 * MB], null)).toBeNull();
+    expect(retentionPerPage([100 * MB, 200 * MB], 0)).toBeNull();
+  });
+
+  it("reports nothing for a build that did not grow", () => {
+    expect(retentionPerPage([200 * MB, 190 * MB, 180 * MB], 500)).toBeNull();
+  });
+});
+
+describe("netGrowthOf", () => {
+  it("measures from the first analyzed level, skipping worker warm-up", () => {
+    expect(netGrowthOf([100 * MB, 200 * MB, 500 * MB])).toBe(300 * MB);
+  });
+
+  it("is zero for a series with nothing in it", () => {
+    expect(netGrowthOf([])).toBe(0);
+  });
+});
+
+describe("strippedHeapCap", () => {
+  it("warns about the cap Next removes from the worker", () => {
+    // Verified by measurement: --max-old-space-size=50 lets the build finish,
+    // --max-heap-size=50 kills it in 374 ms.
+    const warning = strippedHeapCap("--max-old-space-size=2048");
+
+    expect(warning).toContain("never sees it");
+    expect(warning).toContain("--max-heap-size=2048");
+  });
+
+  it("also catches the underscore spelling Next strips", () => {
+    expect(strippedHeapCap("--max_old_space_size=4096")).toContain("--max-heap-size=4096");
+  });
+
+  it("stays quiet for a cap the worker actually inherits", () => {
+    expect(strippedHeapCap("--max-heap-size=2048")).toBeNull();
+  });
+
+  it("stays quiet when nothing is set", () => {
+    expect(strippedHeapCap(undefined)).toBeNull();
+    expect(strippedHeapCap("")).toBeNull();
+  });
+});
+
+describe("diedOfHeapExhaustion", () => {
+  it("recognises the fatal error the worker dies with", () => {
+    const output =
+      "FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory";
+    expect(diedOfHeapExhaustion(output)).toBe(true);
+  });
+
+  it("recognises an explicit heap limit being reached", () => {
+    expect(diedOfHeapExhaustion("FATAL ERROR: Reached heap limit Allocation failed")).toBe(true);
+  });
+
+  it("does not read an ordinary build failure as an OOM", () => {
+    expect(diedOfHeapExhaustion("Type error: Property 'x' does not exist")).toBe(false);
+  });
+});
+
+describe("pagesGeneratedFrom", () => {
+  it("reads how far a finished build got", () => {
+    const output = "✓ Generating static pages using 1 worker (2504/2504) in 49s";
+    expect(pagesGeneratedFrom(output)).toBe(2504);
+  });
+
+  it("reads how far a build got before it died", () => {
+    const output = [
+      "Generating static pages (100/2504)",
+      "Generating static pages (1700/2504)",
+      "FATAL ERROR: JavaScript heap out of memory",
+    ].join("\n");
+    expect(pagesGeneratedFrom(output)).toBe(1700);
+  });
+
+  it("ignores counters that are not about pages", () => {
+    expect(pagesGeneratedFrom("Compiled successfully (12/12)")).toBeNull();
+  });
+
+  it("returns null when the build never printed a count", () => {
+    expect(pagesGeneratedFrom("")).toBeNull();
+  });
+});

--- a/src/build-verdict.ts
+++ b/src/build-verdict.ts
@@ -1,0 +1,185 @@
+import { classifyTrend, type TrendResult } from "./trend.js";
+
+export type BuildSample = {
+  /** Milliseconds since the build started. */
+  atMs: number;
+  rssBytes: number;
+};
+
+/**
+ * Segments the sampling window into equal slices and takes each slice's last
+ * reading.
+ *
+ * A build has no cycles. Its only natural unit of work is a page, and pages are
+ * not observable from outside the worker — so the window is divided by time
+ * instead, which yields a series with the shape semantics the trend classifier
+ * already reads: one level per unit of work. Taking the last sample of each
+ * slice rather than the mean keeps a climb a climb; averaging would flatten the
+ * end of every segment into its start.
+ */
+export function segmentSamples(samples: readonly BuildSample[], segments: number): number[] {
+  // Fewer readings than segments cannot fill them: the same reading would
+  // land in several slices and the repeats would read as a plateau, which is
+  // a healthy shape invented out of missing data.
+  if (segments <= 0 || samples.length < segments) {
+    return [];
+  }
+  const first = samples[0];
+  const last = samples[samples.length - 1];
+  if (first === undefined || last === undefined) {
+    return [];
+  }
+  const span = last.atMs - first.atMs;
+  if (span <= 0) {
+    return [];
+  }
+  const levels: number[] = [];
+  for (let segment = 1; segment <= segments; segment += 1) {
+    const until = first.atMs + (span * segment) / segments;
+    let level: number | undefined;
+    for (const sample of samples) {
+      if (sample.atMs <= until) {
+        level = sample.rssBytes;
+      }
+    }
+    if (level !== undefined) {
+      levels.push(level);
+    }
+  }
+  return levels;
+}
+
+/**
+ * Segments a build needs before its curve can be judged.
+ *
+ * The classifier drops the first delta as warm-up and wants at least three
+ * more, and a worker's first segment is genuinely warm-up: module loading and
+ * JIT, the same reason the runtime ritual discards its baseline delta.
+ */
+export const BUILD_SEGMENTS = 6;
+
+export type BuildTrend = {
+  trend: TrendResult;
+  /** The segmented levels the verdict was read from. */
+  levels: number[];
+};
+
+/**
+ * Per-segment growth a build worker must clear to count as retaining.
+ *
+ * Not the runtime gate. That one is the noise floor of a *post-GC heap* sample,
+ * 256 KiB, and it does not describe RSS: a build worker doing legitimate work
+ * moves tens of megabytes between readings through allocator behaviour alone,
+ * with nothing retained.
+ *
+ * Anchored on the two builds measured on 2026-08-17, same project and same
+ * heap cap:
+ *
+ * | next    | worker RSS across the generation phase | largest healthy segment delta |
+ * |---------|----------------------------------------|-------------------------------|
+ * | 16.2.12 | flat, 428 → 530 MB                     | 17 MB                         |
+ * | 16.3.1  | 1070 → 2960 MB, then OOM               | ~315 MB per segment           |
+ *
+ * 32 MB sits at roughly twice the largest delta a healthy build produced and an
+ * order of magnitude below the leaking one. The consequence to be honest about:
+ * a build retaining less than this per segment reads as stable — and a build
+ * retaining less than this per segment is not one that OOMs.
+ */
+export const BUILD_GROWTH_GATE_BYTES = 32 * 1024 * 1024;
+
+/** Classifies a worker's resident-memory curve. */
+export function classifyBuildSamples(samples: readonly BuildSample[]): BuildTrend {
+  const levels = segmentSamples(samples, BUILD_SEGMENTS);
+  return {
+    trend: classifyTrend(levels, { minGrowthPerCycle: BUILD_GROWTH_GATE_BYTES }),
+    levels,
+  };
+}
+
+/** Growth across the analyzed window, in bytes. */
+export function netGrowthOf(levels: readonly number[]): number {
+  const first = levels[1] ?? levels[0];
+  const last = levels[levels.length - 1];
+  if (first === undefined || last === undefined) {
+    return 0;
+  }
+  return last - first;
+}
+
+/**
+ * Retention per page generated.
+ *
+ * Null when the page count is unknown: a growth figure with an invented
+ * denominator is worse than no figure, and this is the number people quote.
+ */
+export function retentionPerPage(
+  levels: readonly number[],
+  pagesGenerated: number | null
+): number | null {
+  if (pagesGenerated === null || pagesGenerated <= 0) {
+    return null;
+  }
+  const growth = netGrowthOf(levels);
+  return growth <= 0 ? null : growth / pagesGenerated;
+}
+
+/**
+ * The heap cap Next removes from the worker's environment.
+ *
+ * `lib/worker.js` deletes `max-old-space-size` and `max_old_space_size` from
+ * `NODE_OPTIONS` when it spawns an isolated-memory worker, so the flag every
+ * OOM guide recommends never reaches the process that runs out of memory.
+ * Verified by measurement on the #97464 reproduction: a build capped at 50 MB
+ * with `--max-old-space-size` completes, while `--max-heap-size=50` kills it in
+ * 374 ms.
+ */
+export function strippedHeapCap(nodeOptions: string | undefined): string | null {
+  if (nodeOptions === undefined) {
+    return null;
+  }
+  const match = /--max[-_]old[-_]space[-_]size[= ]\s*(\d+)/.exec(nodeOptions);
+  if (match === null) {
+    return null;
+  }
+  const value = match[1] ?? "";
+  return (
+    `NODE_OPTIONS sets --max-old-space-size=${value}, which Next strips from the ` +
+    `static-generation worker's environment — the worker never sees it. Use ` +
+    `--max-heap-size=${value} instead, which survives.`
+  );
+}
+
+const HEAP_DEATH_MARKERS = [
+  "JavaScript heap out of memory",
+  "Reached heap limit",
+  "Ineffective mark-compacts near heap limit",
+];
+
+/** Whether build output carries a V8 heap-limit fatal error. */
+export function diedOfHeapExhaustion(output: string): boolean {
+  return HEAP_DEATH_MARKERS.some((marker) => output.includes(marker));
+}
+
+/**
+ * How many pages the build generated, read from its own progress line.
+ *
+ * Next prints `Generating static pages (1234/2504)`; the largest first number
+ * seen is how far it got, which is the useful figure whether it finished or
+ * died. Null when the build never printed one — an invented denominator would
+ * turn an unknown into a wrong number.
+ */
+export function pagesGeneratedFrom(output: string): number | null {
+  let furthest: number | null = null;
+  for (const line of output.split("\n")) {
+    if (!line.includes("static pages")) {
+      continue;
+    }
+    for (const match of line.matchAll(/\((\d+)\/(\d+)\)/g)) {
+      const done = Number(match[1]);
+      if (Number.isFinite(done) && (furthest === null || done > furthest)) {
+        furthest = done;
+      }
+    }
+  }
+  return furthest;
+}

--- a/src/build-verdict.ts
+++ b/src/build-verdict.ts
@@ -72,18 +72,12 @@ export type BuildTrend = {
  * moves tens of megabytes between readings through allocator behaviour alone,
  * with nothing retained.
  *
- * Anchored on the two builds measured on 2026-08-17, same project and same
- * heap cap:
- *
- * | next    | worker RSS across the generation phase | largest healthy segment delta |
- * |---------|----------------------------------------|-------------------------------|
- * | 16.2.12 | flat, 428 → 530 MB                     | 17 MB                         |
- * | 16.3.1  | 1070 → 2960 MB, then OOM               | ~315 MB per segment           |
- *
- * 32 MB sits at roughly twice the largest delta a healthy build produced and an
- * order of magnitude below the leaking one. The consequence to be honest about:
- * a build retaining less than this per segment reads as stable — and a build
- * retaining less than this per segment is not one that OOMs.
+ * Anchored on two builds of the same project, same heap cap, 2026-08-17:
+ * 16.2.12 stayed flat (428 → 530 MB, largest segment delta 17 MB) while 16.3.1
+ * climbed 1070 → 2960 MB and then OOMed, ~315 MB per segment. 32 MB is roughly
+ * twice the largest healthy delta and an order of magnitude below the leaking
+ * one. The consequence to be honest about: a build retaining less than this per
+ * segment reads as stable — and one retaining less than this does not OOM.
  */
 export const BUILD_GROWTH_GATE_BYTES = 32 * 1024 * 1024;
 

--- a/src/cli-args.test.ts
+++ b/src/cli-args.test.ts
@@ -13,6 +13,7 @@ describe("parseCliArgs", () => {
         requests: null,
         connections: null,
         idleSeconds: null,
+        warmupRequests: null,
         maxOldSpaceMb: null,
         quick: false,
         noResolve: false,
@@ -26,7 +27,7 @@ describe("parseCliArgs", () => {
   it("parses every flag", () => {
     const parsed = parseCliArgs([
       "app", "--routes", "/api,/dashboard", "--cycles", "6", "--requests", "1000",
-      "--connections", "20", "--idle", "8", "--max-old-space", "2048", "--quick",
+      "--connections", "20", "--idle", "8", "--warmup", "50", "--max-old-space", "2048", "--quick",
       "--diff-all", "--no-resolve", "--write-config", "--output", "/tmp/out",
     ]);
     if (parsed.kind !== "run") {
@@ -39,6 +40,7 @@ describe("parseCliArgs", () => {
       requests: 1000,
       connections: 20,
       idleSeconds: 8,
+      warmupRequests: 50,
       maxOldSpaceMb: 2048,
       quick: true,
       noResolve: true,
@@ -306,5 +308,26 @@ describe("--write-config", () => {
 
   it("does not apply to the build command", () => {
     expect(parseCliArgs(["build", "/app", "--write-config"]).kind).toBe("error");
+  });
+});
+
+describe("--warmup", () => {
+  it("parses the size and documents its default", () => {
+    const parsed = parseCliArgs(["/app", "--warmup", "20"]);
+    if (parsed.kind !== "run") throw new Error("expected run");
+    expect(parsed.options.warmupRequests).toBe(20);
+    expect(helpText("0.0.0")).toContain("default 200");
+  });
+
+  it("says why someone would lower it", () => {
+    // The right amount is a property of the app's caches, not of the tool: on
+    // an app that caches per request, warm-up fills the cache the baseline
+    // then measures.
+    expect(helpText("0.0.0")).toContain("cache per request");
+  });
+
+  it("rejects nonsense like every other numeric flag", () => {
+    expect(parseCliArgs(["/app", "--warmup", "0"]).kind).toBe("error");
+    expect(parseCliArgs(["/app", "--warmup", "abc"]).kind).toBe("error");
   });
 });

--- a/src/cli-args.test.ts
+++ b/src/cli-args.test.ts
@@ -233,3 +233,56 @@ describe("--quick", () => {
     expect(helpText("0.0.0")).toContain("--quick");
   });
 });
+
+// A build fails before it can write the standalone bundle the default command
+// needs, so measuring one has to be its own entry point.
+describe("build command", () => {
+  it("parses the app directory after the command", () => {
+    const parsed = parseCliArgs(["build", "/app"]);
+    if (parsed.kind !== "build") throw new Error("expected build");
+    expect(parsed.options.appDir).toBe("/app");
+  });
+
+  it("leaves the default command untouched", () => {
+    const parsed = parseCliArgs(["/app"]);
+    expect(parsed.kind).toBe("run");
+  });
+
+  it("still reaches a directory that happens to be named build", () => {
+    const parsed = parseCliArgs(["./build"]);
+    expect(parsed.kind).toBe("run");
+  });
+
+  it("takes --output", () => {
+    const parsed = parseCliArgs(["build", "/app", "--output", "/tmp/runs"]);
+    if (parsed.kind !== "build") throw new Error("expected build");
+    expect(parsed.options.output).toBe("/tmp/runs");
+  });
+
+  it("rejects load-shaping flags by name instead of ignoring them", () => {
+    // Silently dropping a flag someone typed is how a run ends up measuring
+    // something other than what was asked for.
+    const parsed = parseCliArgs(["build", "/app", "--connections", "50"]);
+    if (parsed.kind !== "error") throw new Error("expected error");
+    expect(parsed.message).toContain("--connections");
+    expect(parsed.message).toContain("does not apply");
+  });
+
+  it("rejects every run-only flag", () => {
+    for (const flag of [["--quick"], ["--diff-all"], ["--no-resolve"], ["--cycles", "6"]]) {
+      const parsed = parseCliArgs(["build", "/app", ...flag]);
+      expect(parsed.kind).toBe("error");
+    }
+  });
+
+  it("shows help when the command has no directory", () => {
+    expect(parseCliArgs(["build"]).kind).toBe("help");
+  });
+
+  it("documents both commands in the help text", () => {
+    const help = helpText("0.0.0");
+    expect(help).toContain("next-leak build <app-dir>");
+    expect(help).toContain("measure the memory of \"next build\"");
+    expect(help).toContain("do not apply to it");
+  });
+});

--- a/src/cli-args.test.ts
+++ b/src/cli-args.test.ts
@@ -17,6 +17,7 @@ describe("parseCliArgs", () => {
         quick: false,
         noResolve: false,
         diffAll: false,
+        writeConfig: false,
         output: null,
       },
     });
@@ -26,7 +27,7 @@ describe("parseCliArgs", () => {
     const parsed = parseCliArgs([
       "app", "--routes", "/api,/dashboard", "--cycles", "6", "--requests", "1000",
       "--connections", "20", "--idle", "8", "--max-old-space", "2048", "--quick",
-      "--diff-all", "--no-resolve", "--output", "/tmp/out",
+      "--diff-all", "--no-resolve", "--write-config", "--output", "/tmp/out",
     ]);
     if (parsed.kind !== "run") {
       throw new Error(`expected run, got ${parsed.kind}`);
@@ -42,6 +43,7 @@ describe("parseCliArgs", () => {
       quick: true,
       noResolve: true,
       diffAll: true,
+      writeConfig: true,
       output: "/tmp/out",
     });
   });
@@ -284,5 +286,25 @@ describe("build command", () => {
     expect(help).toContain("next-leak build <app-dir>");
     expect(help).toContain("measure the memory of \"next build\"");
     expect(help).toContain("do not apply to it");
+  });
+});
+
+describe("--write-config", () => {
+  it("parses the flag and defaults to off", () => {
+    const on = parseCliArgs(["/app", "--write-config"]);
+    const off = parseCliArgs(["/app"]);
+    if (on.kind !== "run" || off.kind !== "run") throw new Error("expected run");
+    expect(on.options.writeConfig).toBe(true);
+    expect(off.options.writeConfig).toBe(false);
+  });
+
+  it("documents itself, including that it never overwrites", () => {
+    const help = helpText("0.0.0");
+    expect(help).toContain("--write-config");
+    expect(help).toContain("never overwrites");
+  });
+
+  it("does not apply to the build command", () => {
+    expect(parseCliArgs(["build", "/app", "--write-config"]).kind).toBe("error");
   });
 });

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -12,11 +12,47 @@ export type CliRunOptions = {
   output: string | null;
 };
 
+export type CliBuildOptions = {
+  appDir: string;
+  output: string | null;
+};
+
 export type ParsedCli =
   | { kind: "run"; options: CliRunOptions }
+  | { kind: "build"; options: CliBuildOptions }
   | { kind: "help" }
   | { kind: "version" }
   | { kind: "error"; message: string };
+
+/** The command name that switches from measuring a server to measuring a build. */
+const BUILD_COMMAND = "build";
+
+/**
+ * Flags that shape HTTP load or the per-route ritual, and so mean nothing to a
+ * build. Rejected by name rather than ignored: silently dropping a flag someone
+ * typed is how a run ends up measuring something other than what was asked.
+ */
+const RUN_ONLY_FLAGS: ReadonlyArray<[keyof CliRunOptions, string]> = [
+  ["routes", "--routes"],
+  ["cycles", "--cycles"],
+  ["requests", "--requests"],
+  ["connections", "--connections"],
+  ["idleSeconds", "--idle"],
+  ["maxOldSpaceMb", "--max-old-space"],
+  ["quick", "--quick"],
+  ["noResolve", "--no-resolve"],
+  ["diffAll", "--diff-all"],
+];
+
+function runOnlyFlagUsed(options: CliRunOptions): string | null {
+  for (const [field, flag] of RUN_ONLY_FLAGS) {
+    const value = options[field];
+    if (value !== null && value !== false) {
+      return flag;
+    }
+  }
+  return null;
+}
 
 type FlagSpec = {
   flag: string;
@@ -73,13 +109,19 @@ Find out whether your Next.js app actually leaks memory — how much, on which
 route, and whose fault it is.
 
 Usage:
-  next-leak <app-dir> [options]
+  next-leak <app-dir> [options]        measure a built server under load
+  next-leak build <app-dir>            measure the memory of "next build"
 
 The app must be built with output: "standalone" (next build). For each
 discovered route, next-leak boots a fresh instrumented process and runs:
 warm-up → GC → baseline snapshot → [load → idle → GC → sample] × cycles →
 snapshot. Evidence (report.html, ISSUE drafts, raw snapshots, run.json) is
 written under the output directory.
+
+The build command needs neither a previous build nor standalone output: it runs
+the build itself and samples the resident memory of each static-generation
+worker, which is where large sites run out of heap while prerendering. It takes
+--output only; the options below shape HTTP load and do not apply to it.
 
 Options:
 ${rows}
@@ -220,6 +262,11 @@ function parseFlagAt(argv: string[], index: number, options: CliRunOptions): Fla
 }
 
 export function parseCliArgs(argv: string[]): ParsedCli {
+  // `next-leak build <dir>` measures a build; anything else keeps the original
+  // meaning. Only an exact first token counts, so a directory named "build" is
+  // still reachable as `next-leak ./build`.
+  const isBuild = argv[0] === BUILD_COMMAND;
+  const rest = isBuild ? argv.slice(1) : argv;
   const options: CliRunOptions = {
     appDir: "",
     routes: null,
@@ -234,8 +281,8 @@ export function parseCliArgs(argv: string[]): ParsedCli {
     output: null,
   };
 
-  for (let index = 0; index < argv.length; index += 1) {
-    const argument = argv[index] ?? "";
+  for (let index = 0; index < rest.length; index += 1) {
+    const argument = rest[index] ?? "";
     if (!argument.startsWith("-")) {
       if (options.appDir !== "") {
         return { kind: "error", message: `unexpected extra argument "${argument}" — one app directory only` };
@@ -243,7 +290,7 @@ export function parseCliArgs(argv: string[]): ParsedCli {
       options.appDir = argument;
       continue;
     }
-    const step = parseFlagAt(argv, index, options);
+    const step = parseFlagAt(rest, index, options);
     if ("done" in step) {
       return step.done;
     }
@@ -252,6 +299,16 @@ export function parseCliArgs(argv: string[]): ParsedCli {
 
   if (options.appDir === "") {
     return { kind: "help" };
+  }
+  if (isBuild) {
+    const misplaced = runOnlyFlagUsed(options);
+    if (misplaced !== null) {
+      return {
+        kind: "error",
+        message: `option "${misplaced}" shapes HTTP load and does not apply to "next-leak build" — see --help`,
+      };
+    }
+    return { kind: "build", options: { appDir: options.appDir, output: options.output } };
   }
   return { kind: "run", options };
 }

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -5,6 +5,7 @@ export type CliRunOptions = {
   requests: number | null;
   connections: number | null;
   idleSeconds: number | null;
+  warmupRequests: number | null;
   maxOldSpaceMb: number | null;
   quick: boolean;
   noResolve: boolean;
@@ -39,6 +40,7 @@ const RUN_ONLY_FLAGS: ReadonlyArray<[keyof CliRunOptions, string]> = [
   ["requests", "--requests"],
   ["connections", "--connections"],
   ["idleSeconds", "--idle"],
+  ["warmupRequests", "--warmup"],
   ["maxOldSpaceMb", "--max-old-space"],
   ["quick", "--quick"],
   ["noResolve", "--no-resolve"],
@@ -76,6 +78,12 @@ const FLAGS: FlagSpec[] = [
   { flag: "--requests", value: "int", argName: "<n>", help: "Requests per cycle (default 5000)" },
   { flag: "--connections", value: "int", argName: "<n>", help: "Concurrent connections (default 100)" },
   { flag: "--idle", value: "int", argName: "<seconds>", help: "Idle seconds before each sample (default 30)" },
+  {
+    flag: "--warmup",
+    value: "int",
+    argName: "<n>",
+    help: "Requests before the baseline snapshot (default 200) — lower it on apps that cache per request",
+  },
   {
     flag: "--max-old-space",
     value: "int",
@@ -144,6 +152,7 @@ const LIMITS: Record<string, number | undefined> = {
   "--requests": 1_000_000,
   "--connections": 10_000,
   "--idle": 3_600,
+  "--warmup": 1_000_000,
   "--max-old-space": 65_536,
 };
 
@@ -197,6 +206,7 @@ function applyNumericFlag(flag: string, value: string, options: CliRunOptions): 
   if (flag === "--requests") options.requests = parsed;
   if (flag === "--connections") options.connections = parsed;
   if (flag === "--idle") options.idleSeconds = parsed;
+  if (flag === "--warmup") options.warmupRequests = parsed;
   if (flag === "--max-old-space") options.maxOldSpaceMb = parsed;
   return FLAG_OK;
 }
@@ -209,6 +219,7 @@ function applyFlag(spec: FlagSpec, value: string, options: CliRunOptions): FlagO
     case "--requests":
     case "--connections":
     case "--idle":
+    case "--warmup":
     case "--max-old-space":
       return applyNumericFlag(spec.flag, value, options);
     case "--quick":
@@ -284,6 +295,7 @@ export function parseCliArgs(argv: string[]): ParsedCli {
     requests: null,
     connections: null,
     idleSeconds: null,
+    warmupRequests: null,
     maxOldSpaceMb: null,
     quick: false,
     noResolve: false,

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -9,6 +9,7 @@ export type CliRunOptions = {
   quick: boolean;
   noResolve: boolean;
   diffAll: boolean;
+  writeConfig: boolean;
   output: string | null;
 };
 
@@ -42,6 +43,7 @@ const RUN_ONLY_FLAGS: ReadonlyArray<[keyof CliRunOptions, string]> = [
   ["quick", "--quick"],
   ["noResolve", "--no-resolve"],
   ["diffAll", "--diff-all"],
+  ["writeConfig", "--write-config"],
 ];
 
 function runOnlyFlagUsed(options: CliRunOptions): string | null {
@@ -92,6 +94,11 @@ const FLAGS: FlagSpec[] = [
     help: "Do not re-measure inconclusive routes with more cycles (default: re-measure once)",
   },
   { flag: "--output", value: "string", argName: "<dir>", help: "Where to write runs (default <app-dir>/.next-leak)" },
+  {
+    flag: "--write-config",
+    value: "none",
+    help: "Write next-leak.config.json for the routes that need sample params, then exit (never overwrites)",
+  },
   { flag: "--help", alias: "-h", value: "none", help: "Show this help" },
   { flag: "--version", alias: "-v", value: "none", help: "Print the version" },
 ];
@@ -210,6 +217,9 @@ function applyFlag(spec: FlagSpec, value: string, options: CliRunOptions): FlagO
     case "--diff-all":
       options.diffAll = true;
       return FLAG_OK;
+    case "--write-config":
+      options.writeConfig = true;
+      return FLAG_OK;
     case "--no-resolve":
       options.noResolve = true;
       return FLAG_OK;
@@ -278,6 +288,7 @@ export function parseCliArgs(argv: string[]): ParsedCli {
     quick: false,
     noResolve: false,
     diffAll: false,
+    writeConfig: false,
     output: null,
   };
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -187,6 +187,7 @@ async function main(): Promise<void> {
     ...(options.requests !== null && { loadRequests: options.requests }),
     ...(options.connections !== null && { connections: options.connections }),
     ...(options.idleSeconds !== null && { idleMs: options.idleSeconds * 1000 }),
+    ...(options.warmupRequests !== null && { warmupRequests: options.warmupRequests }),
     ...(options.maxOldSpaceMb !== null && { maxOldSpaceMb: options.maxOldSpaceMb }),
     ...(options.diffAll && { diffAll: true }),
     ...(options.noResolve && { resolveInconclusive: false }),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
+import { writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { formatBuildReport } from "./build-report.js";
 import { runBuildMeasurement } from "./build-run.js";
@@ -9,8 +11,10 @@ import { checkRuntime } from "./guards.js";
 import { killActiveChildren } from "./launcher.js";
 import { formatReport } from "./report.js";
 import { RouteConfigError } from "./route-config.js";
+import { discoverPagesRoutes, discoverRoutes } from "./manifests.js";
+import { hasPlaceholders, renderConfigSkeleton } from "./route-guidance.js";
 import { runMeasurement } from "./runner.js";
-import { TargetError } from "./target.js";
+import { TargetError, validateTarget } from "./target.js";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json") as { version: string };
@@ -107,6 +111,40 @@ async function runBuildCommand(appDir: string): Promise<void> {
   }
 }
 
+/**
+ * Writes the config for routes that cannot be measured without sample params.
+ *
+ * Refuses to overwrite: someone who already has a config has values in it that
+ * this cannot reconstruct, and losing them to a convenience flag is worse than
+ * printing the fragment and letting them merge it.
+ */
+async function writeConfigSkeleton(appDir: string): Promise<void> {
+  const target = await validateTarget(appDir);
+  const routes = [...discoverRoutes(target.appPaths), ...discoverPagesRoutes(target.pages)]
+    .filter((route) => route.dynamic && route.unaddressableReason === undefined)
+    .map((route) => route.path);
+  const skeleton = renderConfigSkeleton(routes, target.prerender);
+  if (skeleton === null) {
+    console.log("no route needs sample params — nothing to write");
+    return;
+  }
+  const file = path.join(target.appDir, "next-leak.config.json");
+  try {
+    await writeFile(file, `${skeleton}\n`, { flag: "wx" });
+  } catch {
+    console.error(
+      `error: ${file} already exists — not overwriting. The fragment that would ` +
+        `measure the skipped routes:\n\n${skeleton}`
+    );
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`wrote ${file}`);
+  if (hasPlaceholders(skeleton)) {
+    console.log("replace each REPLACE-ME with a value that exists in your app");
+  }
+}
+
 async function main(): Promise<void> {
   const parsed = parseCliArgs(process.argv.slice(2));
   if (handleNonRunCommand(parsed)) {
@@ -117,6 +155,10 @@ async function main(): Promise<void> {
     return;
   }
   if (parsed.kind !== "run") {
+    return;
+  }
+  if (parsed.options.writeConfig) {
+    await writeConfigSkeleton(parsed.options.appDir);
     return;
   }
   if (!hasHeapHeadroom()) {
@@ -154,6 +196,13 @@ async function main(): Promise<void> {
   console.log(formatReport(report));
   if (aborter.signal.aborted) {
     process.exitCode = 130;
+    return;
+  }
+  // A run that measured nothing answered no question, however cleanly it
+  // finished. Exiting 0 there reads as "your app is fine" in CI.
+  if (!report.routes.some((route) => route.status === "measured")) {
+    console.error("error: no route was measured — nothing above is a verdict about your app");
+    process.exitCode = 1;
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,8 @@
 import { spawn } from "node:child_process";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
+import { formatBuildReport } from "./build-report.js";
+import { runBuildMeasurement } from "./build-run.js";
 import { helpText, parseCliArgs, type ParsedCli } from "./cli-args.js";
 import { checkRuntime } from "./guards.js";
 import { killActiveChildren } from "./launcher.js";
@@ -88,9 +90,33 @@ function handleNonRunCommand(parsed: ParsedCli): boolean {
   return false;
 }
 
+/**
+ * Measuring a build needs no heap headroom of its own: nothing is diffed here,
+ * and the memory that matters belongs to the build's own processes.
+ */
+async function runBuildCommand(appDir: string): Promise<void> {
+  const aborter = installInterruptHandlers();
+  const result = await runBuildMeasurement({
+    appDir,
+    signal: aborter.signal,
+    onProgress: (message) => console.error(`· ${message}`),
+  });
+  console.log(formatBuildReport(result));
+  if (aborter.signal.aborted) {
+    process.exitCode = 130;
+  }
+}
+
 async function main(): Promise<void> {
   const parsed = parseCliArgs(process.argv.slice(2));
-  if (handleNonRunCommand(parsed) || parsed.kind !== "run") {
+  if (handleNonRunCommand(parsed)) {
+    return;
+  }
+  if (parsed.kind === "build") {
+    await runBuildCommand(parsed.options.appDir);
+    return;
+  }
+  if (parsed.kind !== "run") {
     return;
   }
   if (!hasHeapHeadroom()) {

--- a/src/confidence.test.ts
+++ b/src/confidence.test.ts
@@ -596,3 +596,71 @@ describe("warrantsIssueDraft", () => {
     ).toBe(false);
   });
 });
+
+// Warm-up loads modules and warms the JIT — work that does not repeat. On an
+// app whose caches key on the request it also fills those caches, and the
+// baseline then measures the warm-up instead of the app's resting size.
+describe("warm-up baseline contamination", () => {
+  const sample = (mb: number): HeapSample => ({
+    gcExposed: true,
+    heapUsed: mb * 1024 * 1024,
+    rss: 3 * mb * 1024 * 1024,
+    external: 0,
+    arrayBuffers: 0,
+  });
+
+  const warnings = (heapMb: number[], warmupRequests?: number) =>
+    assessConfidence({
+      trend: { verdict: "stable", growthPerCycle: 0, deltas: [] },
+      loadOutcomes: [],
+      settleOutcomes: [],
+      memorySamples: heapMb.map(sample),
+      ...(warmupRequests !== undefined && { warmupRequests }),
+    }).warnings.filter((warning) => warning.code === "warm-up-baseline");
+
+  it("flags the measured #97424 shape", () => {
+    // Baseline 861.7 MB against 129.4 MB on the very next cycle: 85% of the
+    // baseline was warm-up, and every delta was measured from that start.
+    const found = warnings([861.7, 129.4, 253.0, 179.1, 107.1, 184.1, 235.5], 200);
+
+    expect(found).toHaveLength(1);
+    expect(found[0]?.detail).toContain("861.70 MB");
+    expect(found[0]?.detail).toContain("129.40 MB");
+    expect(found[0]?.detail).toContain("200 warm-up requests");
+    expect(found[0]?.detail).toContain("--warmup");
+  });
+
+  it("stays quiet on a healthy app", () => {
+    // 7.3 → 7.1 MB: 3% of the baseline, and 0.2 MB in absolute terms.
+    expect(warnings([7.3, 7.1, 7.1, 7.2, 7.2, 7.2, 7.3])).toHaveLength(0);
+  });
+
+  it("stays quiet on the #96533 app, which drops 3% of 27 MB", () => {
+    expect(warnings([27.1, 26.3, 27.3, 27.6, 27.8, 27.8, 27.9])).toHaveLength(0);
+  });
+
+  it("stays quiet when a small app sheds most of a small baseline", () => {
+    // 80% of 10 MB is still only 8 MB — nothing worth re-running for.
+    expect(warnings([10, 2, 2.1, 2.2, 2.3])).toHaveLength(0);
+  });
+
+  it("stays quiet when the baseline is below the first cycle", () => {
+    // The ordinary shape: warm-up costs a little and the app grows into it.
+    expect(warnings([29.4, 31.5, 32.3, 32.1])).toHaveLength(0);
+  });
+
+  it("does not weaken the verdict or block an issue draft", () => {
+    // It is a statement about where the baseline sat, not about whether the
+    // evidence supports the verdict.
+    const report = assessConfidence({
+      trend: { verdict: "leak", growthPerCycle: 40 * 1024 * 1024, deltas: [40e6, 41e6, 42e6, 43e6, 44e6] },
+      loadOutcomes: [],
+      settleOutcomes: [],
+      memorySamples: [861.7, 129.4, 253.0, 179.1, 107.1, 184.1, 235.5].map(sample),
+    });
+
+    expect(report.warnings.some((warning) => warning.code === "warm-up-baseline")).toBe(true);
+    expect(report.supersededVerdict).toBeUndefined();
+    expect(warrantsIssueDraft({ trend: { verdict: "leak", growthPerCycle: 0, deltas: [] }, confidence: report })).toBe(true);
+  });
+});

--- a/src/confidence.ts
+++ b/src/confidence.ts
@@ -16,6 +16,9 @@ import { MIN_GROWTH_NOISE_FLOOR, type TrendResult, type TrendVerdict } from "./t
  * `thin-evidence`       — a leak called on too few cycles for its size
  * `near-heap-ceiling`   — the heap approached the cap the process ran under,
  *   so the curve was measured against a ceiling instead of running free
+ * `warm-up-baseline`    — the baseline sat far above the level the cycles
+ *   settled at, so it carries warm-up's own retention rather than the app's
+ *   resting size
  */
 export type WarningCode =
   | "unsettled"
@@ -26,7 +29,8 @@ export type WarningCode =
   | "spiky-growth"
   | "near-threshold"
   | "thin-evidence"
-  | "near-heap-ceiling";
+  | "near-heap-ceiling"
+  | "warm-up-baseline";
 
 export type MeasurementWarning = {
   code: WarningCode;
@@ -57,6 +61,8 @@ export type ConfidenceInput = {
   memorySamples?: readonly HeapSample[];
   /** Old-space cap the measured process ran under (MB). */
   maxOldSpaceMb?: number;
+  /** Warm-up requests the run sent before the baseline, for the warm-up check. */
+  warmupRequests?: number;
 };
 
 /**
@@ -286,6 +292,56 @@ function heapCeilingWarnings(input: ConfidenceInput): MeasurementWarning[] {
 }
 
 /**
+ * Share of the baseline that has to drain away before it looks like warm-up's
+ * memory rather than the app's resting size.
+ *
+ * Warm-up exists to load modules and warm the JIT — work that does not repeat.
+ * On an app whose caches key on the request it also fills those caches, and the
+ * baseline then measures the warm-up rather than the app. Measured on the
+ * vercel/next.js#97424 reproduction: baseline 861.7 MB against 129.4 MB on the
+ * very next cycle, so 85% of the baseline was warm-up. The healthy fixture
+ * drops 0.2 MB of 7.3 (3%), and the #96533 app 0.8 MB of 27.1 (3%).
+ */
+const WARM_UP_BASELINE_SHARE = 0.5;
+
+/**
+ * And an absolute floor, so a tiny app dropping most of a tiny baseline stays
+ * quiet. A run that sheds less than this between the baseline and the first
+ * cycle has nothing worth re-running for.
+ */
+const WARM_UP_BASELINE_FLOOR_BYTES = 16 * 1024 * 1024;
+
+/**
+ * Whether the baseline carries memory the warm-up put there.
+ *
+ * Reported, never corrected: moving the baseline would hide the problem, and
+ * changing the default warm-up size would change every existing verdict. The
+ * user gets the fact and the knob (`--warmup`).
+ */
+function warmUpBaselineWarnings(input: ConfidenceInput): MeasurementWarning[] {
+  const samples = input.memorySamples;
+  const baseline = samples?.[0]?.heapUsed;
+  const firstCycle = samples?.[1]?.heapUsed;
+  if (baseline === undefined || firstCycle === undefined) {
+    return [];
+  }
+  const drained = baseline - firstCycle;
+  if (drained < WARM_UP_BASELINE_FLOOR_BYTES || drained < baseline * WARM_UP_BASELINE_SHARE) {
+    return [];
+  }
+  const warmup =
+    input.warmupRequests === undefined ? "" : ` (${input.warmupRequests} warm-up requests)`;
+  return [{
+    code: "warm-up-baseline",
+    detail:
+      `the baseline was ${mb(baseline)} and the first cycle ${mb(firstCycle)} — ` +
+      `${pct(drained, baseline)} of it drained away, so it carries warm-up's own ` +
+      `retention rather than the app's resting size${warmup}; every delta is ` +
+      `measured from that inflated start. Lower --warmup if the app caches per request`,
+  }];
+}
+
+/**
  * Invalidity, not noise: the measurement did not observe what it claims to.
  * Only a leak verdict is withdrawn — a stable one keeps its warnings, since
  * silently missing a leak costs the user less than a false accusation. And
@@ -378,6 +434,7 @@ export function assessConfidence(input: ConfidenceInput): ConfidenceReport {
     ...noiseFloorWarnings(input.trend, minGrowth),
     ...thinEvidenceWarnings(input.trend, minGrowth),
     ...heapCeilingWarnings(input),
+    ...warmUpBaselineWarnings(input),
   ];
 
   return {

--- a/src/heap-diff.test.ts
+++ b/src/heap-diff.test.ts
@@ -1,6 +1,10 @@
+import { mkdtemp, open } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   assertReadableSnapshot,
+  SnapshotError,
   diffAgainstBaseline,
   diffSnapshotFiles,
   retainerChain,
@@ -591,5 +595,43 @@ describe("assertReadableSnapshot", () => {
     await expect(
       assertReadableSnapshot(await write("pad.heapsnapshot", `\n  ${body}\n`))
     ).resolves.toBeUndefined();
+  });
+});
+
+// A snapshot is parsed by reading it into one string, and V8 caps a string at
+// 512 MB. Measured 2026-08-18 on the vercel/next.js#97424 reproduction: the
+// second pass wrote a 1.7 GB baseline, node:fs died with `RangeError: Invalid
+// string length`, and a finished measurement went with it.
+describe("snapshots too large to parse", () => {
+  it("refuses a snapshot past the maximum string length, naming the size", async () => {
+    const { constants } = await import("node:buffer");
+    const dir = await mkdtemp(path.join(tmpdir(), "next-leak-huge-"));
+    const file = path.join(dir, "baseline.heapsnapshot");
+    // Sparse file: the size is what matters, not the bytes.
+    const handle = await open(file, "w");
+    await handle.write('{"snapshot":{', 0);
+    await handle.truncate(constants.MAX_STRING_LENGTH + 1024);
+    await handle.close();
+
+    await expect(assertReadableSnapshot(file)).rejects.toThrow(SnapshotError);
+    await expect(assertReadableSnapshot(file)).rejects.toThrow(/cannot be parsed/);
+    await expect(assertReadableSnapshot(file)).rejects.toThrow(
+      /measurement itself is unaffected/
+    );
+  });
+
+  it("does not blame size for a file just under the limit", async () => {
+    // Still rejected — it is a sparse file, so the truncation guard catches
+    // it — but the size guard must not be the one to fire, or every large
+    // healthy snapshot would be refused.
+    const { constants } = await import("node:buffer");
+    const dir = await mkdtemp(path.join(tmpdir(), "next-leak-big-"));
+    const file = path.join(dir, "baseline.heapsnapshot");
+    const handle = await open(file, "w");
+    await handle.write('{"snapshot":{', 0);
+    await handle.truncate(constants.MAX_STRING_LENGTH - 1024);
+    await handle.close();
+
+    await expect(assertReadableSnapshot(file)).rejects.not.toThrow(/cannot be parsed/);
   });
 });

--- a/src/heap-diff.ts
+++ b/src/heap-diff.ts
@@ -279,6 +279,7 @@ const PROBE_BYTES = 512;
  */
 export async function assertReadableSnapshot(file: string): Promise<void> {
   const { open, stat } = await import("node:fs/promises");
+  const { constants } = await import("node:buffer");
   let size: number;
   try {
     size = (await stat(file)).size;
@@ -287,6 +288,22 @@ export async function assertReadableSnapshot(file: string): Promise<void> {
   }
   if (size === 0) {
     throw new SnapshotError(`heap snapshot is empty: ${file}`);
+  }
+  // A snapshot is parsed by reading it into one string, and V8 caps a string
+  // at 512 MB. Past that the read dies with `RangeError: Invalid string
+  // length` from inside node:fs, which no amount of care in this file
+  // prevents — so refuse before the attempt and say what happened. Measured
+  // 2026-08-18 on the vercel/next.js#97424 reproduction: the second pass
+  // wrote a 1.7 GB baseline and the whole run died at the diff, taking a
+  // completed measurement with it.
+  if (size > constants.MAX_STRING_LENGTH) {
+    throw new SnapshotError(
+      `heap snapshot is ${(size / (1024 * 1024)).toFixed(0)} MB, past the ` +
+        `${(constants.MAX_STRING_LENGTH / (1024 * 1024)).toFixed(0)} MB a single string can ` +
+        `hold, so it cannot be parsed: ${file}. The measurement itself is unaffected — ` +
+        `only the snapshot diff, which names the retaining object, is unavailable. ` +
+        `Lower --requests or --cycles to keep the heap smaller if you need it`
+    );
   }
 
   const handle = await open(file, "r");

--- a/src/isr.test.ts
+++ b/src/isr.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { REVALIDATE_HEADER, planRevalidation, revalidateSecondsFor, revalidates } from "./isr.js";
+import { prerenderManifestSchema, type PrerenderManifest } from "./manifests.js";
+
+// Shaped after the real prerender-manifest.json of the vercel/next.js#96533
+// reproduction: 200 concrete /posts/post-N entries at 3600s, all pointing back
+// at the /posts/[slug] template, which itself carries no period.
+const ISR_MANIFEST: PrerenderManifest = prerenderManifestSchema.parse({
+  version: 4,
+  routes: {
+    "/_global-error": { initialRevalidateSeconds: false, srcRoute: "/_global-error" },
+    "/posts/post-0": { initialRevalidateSeconds: 3600, srcRoute: "/posts/[slug]" },
+    "/posts/post-1": { initialRevalidateSeconds: 3600, srcRoute: "/posts/[slug]" },
+  },
+  dynamicRoutes: { "/posts/[slug]": { routeRegex: "^/posts/([^/]+?)(?:/)?$" } },
+  preview: { previewModeId: "f9fe17d31dc264aa7d67957a9554580d" },
+});
+
+describe("revalidateSecondsFor", () => {
+  it("finds a dynamic template's period on its concrete entries", () => {
+    // The template itself carries none — this is the case that matters, and
+    // reading only the template would find nothing.
+    expect(revalidateSecondsFor(ISR_MANIFEST, "/posts/[slug]")).toBe(3600);
+  });
+
+  it("reads a concrete route's own period", () => {
+    expect(revalidateSecondsFor(ISR_MANIFEST, "/posts/post-1")).toBe(3600);
+  });
+
+  it("treats a prerendered route that never revalidates as not ISR", () => {
+    expect(revalidateSecondsFor(ISR_MANIFEST, "/_global-error")).toBeNull();
+    expect(revalidates(ISR_MANIFEST, "/_global-error")).toBe(false);
+  });
+
+  it("returns null for a route the manifest does not mention", () => {
+    expect(revalidateSecondsFor(ISR_MANIFEST, "/about")).toBeNull();
+  });
+
+  it("returns null when there is no manifest at all", () => {
+    expect(revalidateSecondsFor(undefined, "/posts/[slug]")).toBeNull();
+  });
+});
+
+describe("planRevalidation", () => {
+  it("drives an ISR route with the build's own previewModeId", () => {
+    const plan = planRevalidation(ISR_MANIFEST, "/posts/[slug]", undefined);
+    if (plan.kind !== "drive") throw new Error("expected drive");
+
+    expect(plan.headers[REVALIDATE_HEADER]).toBe("f9fe17d31dc264aa7d67957a9554580d");
+  });
+
+  it("adds nothing to a route that is not ISR", () => {
+    const plan = planRevalidation(ISR_MANIFEST, "/about", undefined);
+    expect(plan.kind).toBe("not-isr");
+  });
+
+  it("adds nothing when there is no manifest", () => {
+    expect(planRevalidation(undefined, "/posts/[slug]", undefined).kind).toBe("not-isr");
+  });
+
+  it("leaves a user-supplied header untouched", () => {
+    const plan = planRevalidation(ISR_MANIFEST, "/posts/[slug]", {
+      [REVALIDATE_HEADER]: "mine",
+    });
+    if (plan.kind !== "drive") throw new Error("expected drive");
+
+    expect(plan.headers).toEqual({});
+  });
+
+  it("matches a user-supplied header whatever its casing", () => {
+    const plan = planRevalidation(ISR_MANIFEST, "/posts/[slug]", {
+      "X-Prerender-Revalidate": "mine",
+    });
+    if (plan.kind !== "drive") throw new Error("expected drive");
+
+    expect(plan.headers).toEqual({});
+  });
+
+  it("refuses to guess when the manifest carries no previewModeId", () => {
+    // Measuring here would serve the cache and report a flat, meaningless
+    // curve — the silent false negative this exists to close.
+    const withoutPreview = prerenderManifestSchema.parse({
+      routes: { "/posts/post-0": { initialRevalidateSeconds: 3600, srcRoute: "/posts/[slug]" } },
+    });
+    const plan = planRevalidation(withoutPreview, "/posts/[slug]", undefined);
+    if (plan.kind !== "cannot-drive") throw new Error("expected cannot-drive");
+
+    expect(plan.reason).toContain("3600s");
+    expect(plan.reason).toContain("previewModeId");
+    expect(plan.reason).toContain(REVALIDATE_HEADER);
+  });
+});
+
+describe("prerenderManifestSchema", () => {
+  it("tolerates the fields the tool does not read", () => {
+    const parsed = prerenderManifestSchema.parse({
+      version: 4,
+      routes: { "/a": { initialRevalidateSeconds: 60, dataRoute: "/a.rsc", allowHeader: ["host"] } },
+      notFoundRoutes: [],
+      preview: { previewModeId: "x", previewModeSigningKey: "y" },
+    });
+
+    expect(parsed.routes?.["/a"]?.initialRevalidateSeconds).toBe(60);
+  });
+
+  it("accepts a manifest with no routes at all", () => {
+    expect(prerenderManifestSchema.parse({ version: 4 }).routes).toBeUndefined();
+  });
+});
+
+// The header the plan produces is merged under any the user set, so a bespoke
+// revalidation path always wins. This is the merge the runner performs.
+describe("header merge order", () => {
+  it("keeps the user's value when both exist", () => {
+    const plan = planRevalidation(ISR_MANIFEST, "/posts/[slug]", { [REVALIDATE_HEADER]: "mine" });
+    const driven = plan.kind === "drive" ? plan.headers : {};
+    const merged = { ...driven, ...{ [REVALIDATE_HEADER]: "mine" } };
+
+    expect(merged[REVALIDATE_HEADER]).toBe("mine");
+  });
+
+  it("supplies the manifest value when the user set none", () => {
+    const plan = planRevalidation(ISR_MANIFEST, "/posts/[slug]", undefined);
+    const driven = plan.kind === "drive" ? plan.headers : {};
+    const merged = { ...driven };
+
+    expect(merged[REVALIDATE_HEADER]).toBe("f9fe17d31dc264aa7d67957a9554580d");
+  });
+
+  it("adds nothing for a route that is not ISR", () => {
+    const plan = planRevalidation(ISR_MANIFEST, "/about", undefined);
+    const driven = plan.kind === "drive" ? plan.headers : {};
+
+    expect(Object.keys(driven)).toHaveLength(0);
+  });
+});

--- a/src/isr.ts
+++ b/src/isr.ts
@@ -1,0 +1,83 @@
+import type { PrerenderManifest } from "./manifests.js";
+
+/**
+ * The header Next accepts as an authentic revalidation request.
+ *
+ * Sent with the build's own `previewModeId`, it makes the server re-render the
+ * page instead of serving the cached one. Without it, load against an ISR route
+ * exercises the static cache and nothing else — measured on the
+ * vercel/next.js#96533 reproduction, the same app reports `leak` with this
+ * header and `stable` without it.
+ */
+export const REVALIDATE_HEADER = "x-prerender-revalidate";
+
+/**
+ * The revalidation period in force for a route, or null when it has none.
+ *
+ * Accepts either a concrete path (`/posts/post-1`) or a dynamic template
+ * (`/posts/[slug]`): the period lives on concrete entries, and a template
+ * inherits it from any entry whose `srcRoute` points back at it.
+ */
+export function revalidateSecondsFor(
+  manifest: PrerenderManifest | undefined,
+  route: string
+): number | null {
+  const routes = manifest?.routes;
+  if (routes === undefined) {
+    return null;
+  }
+  const direct = routes[route]?.initialRevalidateSeconds;
+  if (typeof direct === "number") {
+    return direct;
+  }
+  for (const entry of Object.values(routes)) {
+    if (entry.srcRoute === route && typeof entry.initialRevalidateSeconds === "number") {
+      return entry.initialRevalidateSeconds;
+    }
+  }
+  return null;
+}
+
+/** Whether a route is served from the ISR cache and needs driving. */
+export function revalidates(manifest: PrerenderManifest | undefined, route: string): boolean {
+  return revalidateSecondsFor(manifest, route) !== null;
+}
+
+export type RevalidationPlan =
+  | { kind: "not-isr" }
+  | { kind: "drive"; headers: Record<string, string> }
+  /** ISR, but the manifest cannot supply what an authentic request needs. */
+  | { kind: "cannot-drive"; reason: string };
+
+/**
+ * How to make a route re-render, given what the build tells us.
+ *
+ * A header the user set themselves wins untouched: someone driving a bespoke
+ * revalidation path knows more about it than the manifest does.
+ */
+export function planRevalidation(
+  manifest: PrerenderManifest | undefined,
+  route: string,
+  userHeaders: Record<string, string> | undefined
+): RevalidationPlan {
+  const userSupplied = Object.keys(userHeaders ?? {}).some(
+    (name) => name.toLowerCase() === REVALIDATE_HEADER
+  );
+  if (userSupplied) {
+    return { kind: "drive", headers: {} };
+  }
+  if (!revalidates(manifest, route)) {
+    return { kind: "not-isr" };
+  }
+  const previewModeId = manifest?.preview?.previewModeId;
+  if (previewModeId === undefined || previewModeId === "") {
+    return {
+      kind: "cannot-drive",
+      reason:
+        `revalidates every ${revalidateSecondsFor(manifest, route)}s, but the build's ` +
+        `prerender-manifest.json carries no previewModeId — load would serve the cache ` +
+        `and measure nothing. Set "${REVALIDATE_HEADER}" in next-leak.config.json to drive it.`,
+    };
+  }
+  return { kind: "drive", headers: { [REVALIDATE_HEADER]: previewModeId } };
+}

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -70,6 +70,20 @@ export function killActiveChildren(): void {
 }
 
 /**
+ * Puts a process this tool spawned under the same interrupt safety as a
+ * measured app — a build launched by `next-leak build` must not outlive a
+ * Ctrl+C either.
+ */
+export function registerChild(child: ChildProcess): void {
+  activeChildren.add(child);
+  child.once("exit", () => activeChildren.delete(child));
+}
+
+export function unregisterChild(child: ChildProcess): void {
+  activeChildren.delete(child);
+}
+
+/**
  * Turns a stack dump into a sentence when the cause is recognisable. Seen in
  * the wild: a webpack `output: standalone` build that ships without
  * `@swc/helpers`, which fails identically when started by hand — the tool is

--- a/src/load.test.ts
+++ b/src/load.test.ts
@@ -281,3 +281,53 @@ describe("bounded key cardinality", () => {
     expect(seen.size).toBeGreaterThan(20);
   });
 });
+
+// A failed load phase says the run did not happen; it does not say whose fault
+// that is, and the two causes need opposite responses from the user.
+describe("saturation is not the same as a broken route", () => {
+  it("names --connections when the failures are timeouts", async () => {
+    // The #97424 shape: 0 non-2xx, all timeouts, because each render fans out
+    // to 30 fetches and 5 concurrent renders is already too many.
+    const port = await listen((_request, response) => {
+      // Never answers: every request times out.
+      void response;
+    });
+
+    const failure = await runLoadPhase({
+      url: `http://127.0.0.1:${port}/`,
+      amount: 8,
+      connections: 4,
+    }).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(LoadError);
+    const message = (failure as LoadError).message;
+    expect(message).toContain("timeouts rather than error responses");
+    expect(message).toContain("--connections (currently 4)");
+    expect(message).toContain("before concluding anything about memory");
+  }, 60_000);
+
+  it("blames the route when it answers with errors, and does not suggest less load", async () => {
+    const port = await listen((_request, response) => {
+      response.statusCode = 500;
+      response.end("no");
+    });
+
+    const failure = await runLoadPhase({
+      url: `http://127.0.0.1:${port}/`,
+      amount: 20,
+      connections: 2,
+    }).catch((error: unknown) => error);
+
+    const message = (failure as LoadError).message;
+    expect(message).toContain("answered with errors under load");
+    expect(message).not.toContain("--connections");
+  });
+
+  it("says nothing extra when the load stayed within budget", async () => {
+    const port = await listen((_request, response) => response.end("ok"));
+
+    await expect(
+      runLoadPhase({ url: `http://127.0.0.1:${port}/`, amount: 10, connections: 2 })
+    ).resolves.toBeDefined();
+  });
+});

--- a/src/load.test.ts
+++ b/src/load.test.ts
@@ -190,3 +190,94 @@ describe("request headers", () => {
   }, 30_000);
 });
 
+
+// `{n}` gives every request its own URL; `{n%N}` gives N distinct URLs
+// revisited. The reported leaks turn on the second shape — #96533 revalidates
+// a fixed set of 200 posts over and over — and until now only the first
+// existed.
+describe("bounded key cardinality", () => {
+  it("cycles through exactly N distinct paths", async () => {
+    const seen = new Set<string>();
+    const port = await listen((request, response) => {
+      seen.add(request.url ?? "");
+      response.end("ok");
+    });
+
+    await runLoadPhase({
+      url: `http://127.0.0.1:${port}/posts/post-{n%5}`,
+      amount: 60,
+      connections: 4,
+    });
+
+    expect(seen.size).toBe(5);
+    expect([...seen].sort()).toEqual([
+      "/posts/post-0",
+      "/posts/post-1",
+      "/posts/post-2",
+      "/posts/post-3",
+      "/posts/post-4",
+    ]);
+  });
+
+  it("revisits the same keys rather than growing without limit", async () => {
+    const counts = new Map<string, number>();
+    const port = await listen((request, response) => {
+      const path = request.url ?? "";
+      counts.set(path, (counts.get(path) ?? 0) + 1);
+      response.end("ok");
+    });
+
+    await runLoadPhase({
+      url: `http://127.0.0.1:${port}/p/{n%3}`,
+      amount: 30,
+      connections: 2,
+    });
+
+    expect(counts.size).toBe(3);
+    // Every key seen more than once: that is what "revisited" means.
+    expect([...counts.values()].every((count) => count > 1)).toBe(true);
+  });
+
+  it("keeps the error budget working on bounded paths", async () => {
+    const port = await listen((_request, response) => {
+      response.statusCode = 500;
+      response.end("no");
+    });
+
+    await expect(
+      runLoadPhase({ url: `http://127.0.0.1:${port}/p/{n%4}`, amount: 20, connections: 2 })
+    ).rejects.toBeInstanceOf(LoadError);
+  });
+
+  it("preserves the query string alongside the bound", async () => {
+    const seen = new Set<string>();
+    const port = await listen((request, response) => {
+      seen.add(request.url ?? "");
+      response.end("ok");
+    });
+
+    await runLoadPhase({
+      url: `http://127.0.0.1:${port}/p/{n%2}?weightKb=8`,
+      amount: 10,
+      connections: 2,
+    });
+
+    expect([...seen].sort()).toEqual(["/p/0?weightKb=8", "/p/1?weightKb=8"]);
+  });
+
+  it("leaves unbounded {n} giving every request its own URL", async () => {
+    const seen = new Set<string>();
+    const port = await listen((request, response) => {
+      seen.add(request.url ?? "");
+      response.end("ok");
+    });
+
+    await runLoadPhase({
+      url: `http://127.0.0.1:${port}/p/{n}`,
+      amount: 25,
+      connections: 2,
+    });
+
+    expect(seen.size).toBeGreaterThan(20);
+  });
+});

--- a/src/load.ts
+++ b/src/load.ts
@@ -1,5 +1,5 @@
 import autocannon from "autocannon";
-import { UNIQUE_MARKER } from "./route-config.js";
+import { boundedMarkerOf, UNIQUE_MARKER } from "./route-config.js";
 
 export type LoadPhaseOptions = {
   url: string;
@@ -52,6 +52,35 @@ async function describeRedirect(url: string): Promise<string | null> {
   }
 }
 
+/**
+ * Cycles a request path through exactly `bound` distinct values.
+ *
+ * The counter is shared across connections on purpose: what matters is how many
+ * distinct keys the app sees over the phase, not which connection sent which.
+ */
+function boundedRequestSequence(
+  fullUrl: string,
+  bounded: { marker: string; bound: number }
+): { origin: string; requests: Array<Record<string, unknown>> } {
+  // Deliberately not `parsed.pathname`: that returns the percent-encoded form,
+  // where `{n%5}` has become `%7Bn%255%7D` and the marker no longer matches.
+  const parsed = new URL(fullUrl);
+  const template = fullUrl.slice(parsed.origin.length);
+  let counter = 0;
+  return {
+    origin: parsed.origin,
+    requests: [
+      {
+        setupRequest: (request: Record<string, unknown>) => {
+          const value = String(counter % bounded.bound);
+          counter += 1;
+          return { ...request, path: template.split(bounded.marker).join(value) };
+        },
+      },
+    ],
+  };
+}
+
 /** Runs one bounded load phase and fails when the error budget is exceeded. */
 export async function runLoadPhase(options: LoadPhaseOptions): Promise<LoadPhaseResult> {
   // `{n}` in the path means "every request must be a distinct URL" — the only
@@ -60,12 +89,21 @@ export async function runLoadPhase(options: LoadPhaseOptions): Promise<LoadPhase
   const unique = options.url.includes(UNIQUE_MARKER);
   const url = unique ? options.url.split(UNIQUE_MARKER).join("[<id>]") : options.url;
 
+  // `{n%N}` needs a *bounded* set of distinct URLs, revisited across cycles —
+  // the shape a real ISR cache or a keyed LRU actually has. autocannon's
+  // idReplacement is unbounded by construction, so the sequence is generated
+  // here instead, one path per request.
+  const bounded = boundedMarkerOf(options.url);
+  const boundedRequests =
+    bounded === null ? undefined : boundedRequestSequence(options.url, bounded);
+
   const raw = await autocannon({
-    url,
+    url: boundedRequests === undefined ? url : boundedRequests.origin,
     amount: options.amount,
     connections: options.connections,
     ...(options.headers !== undefined && { headers: options.headers }),
     ...(unique && { idReplacement: true }),
+    ...(boundedRequests !== undefined && { requests: boundedRequests.requests }),
   });
 
   const result: LoadPhaseResult = {

--- a/src/load.ts
+++ b/src/load.ts
@@ -81,6 +81,35 @@ function boundedRequestSequence(
   };
 }
 
+/**
+ * What the failures look like, and which knob addresses them.
+ *
+ * A failed load phase says the run did not happen; it does not say whose fault
+ * that is, and the two causes need opposite responses. Measured on the
+ * vercel/next.js#97424 reproduction: 103 of 300 requests failed with 0 non-2xx
+ * and 70 timeouts — the app could not serve 5 concurrent renders that each fan
+ * out to 30 fetches. Reading that as "the route is broken" sends someone to
+ * file a bug against their own app; reading it as saturation sends them to
+ * lower the load, which is what actually gets a measurement.
+ */
+function diagnoseFailure(result: LoadPhaseResult, connections: number): string {
+  if (result.timeouts > result.non2xx) {
+    return (
+      ` — the failures are timeouts rather than error responses, so the load may ` +
+      `simply be more than the app or something it calls can serve; lower ` +
+      `--connections (currently ${connections}) and re-run before concluding ` +
+      `anything about memory`
+    );
+  }
+  if (result.non2xx > 0) {
+    return (
+      ` — the app answered with errors under load, which is a fault in the route ` +
+      `rather than too much traffic; fix that before measuring it`
+    );
+  }
+  return "";
+}
+
 /** Runs one bounded load phase and fails when the error budget is exceeded. */
 export async function runLoadPhase(options: LoadPhaseOptions): Promise<LoadPhaseResult> {
   // `{n}` in the path means "every request must be a distinct URL" — the only
@@ -135,7 +164,7 @@ export async function runLoadPhase(options: LoadPhaseOptions): Promise<LoadPhase
         `(${result.non2xx} non-2xx, ${result.errors} errors, ${result.timeouts} timeouts` +
         (unanswered > 0 ? `, ${unanswered} with no recorded response` : "") +
         ")" +
-        (redirect === null ? "" : ` — ${redirect}`),
+        (redirect === null ? diagnoseFailure(result, options.connections) : ` — ${redirect}`),
       result
     );
   }

--- a/src/manifests.ts
+++ b/src/manifests.ts
@@ -22,6 +22,31 @@ export const routesManifestSchema = z.looseObject({
 });
 export type RoutesManifest = z.infer<typeof routesManifestSchema>;
 
+/**
+ * `.next/prerender-manifest.json` — only the fields ISR handling relies on.
+ *
+ * `routes` holds concrete prerendered paths; a dynamic template's revalidation
+ * period lives on those entries, linked back by `srcRoute`, not on the
+ * `dynamicRoutes` entry for the template itself. On the vercel/next.js#96533
+ * reproduction, `/posts/[slug]` carries no period while its 200 concrete
+ * `/posts/post-N` entries each carry `initialRevalidateSeconds: 3600` with
+ * `srcRoute: "/posts/[slug]"`.
+ */
+export const prerenderManifestSchema = z.looseObject({
+  routes: z
+    .record(
+      z.string(),
+      z.looseObject({
+        // `false` on a route that is prerendered but never revalidates.
+        initialRevalidateSeconds: z.union([z.number(), z.literal(false)]).optional(),
+        srcRoute: z.string().nullable().optional(),
+      })
+    )
+    .optional(),
+  preview: z.looseObject({ previewModeId: z.string() }).optional(),
+});
+export type PrerenderManifest = z.infer<typeof prerenderManifestSchema>;
+
 export type RouteKind = "page" | "route-handler";
 
 export type DiscoveredRoute = {

--- a/src/process-tree.test.ts
+++ b/src/process-tree.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { descendantsOf, isStaticGenWorker, parseProcessTable } from "./process-tree.js";
+
+// Real `ps -axo pid,ppid,rss,command` output, trimmed to the build's own
+// processes, captured while reproducing vercel/next.js#97464 on 16.3.1.
+const REAL_PS_OUTPUT = `  PID  PPID    RSS COMMAND
+    1     0  17488 /sbin/launchd
+97103 95996   2976 /bin/zsh -c npm run build
+97107 97103  49216 npm run build
+97131 97107 337408 next-build (v16.3.1)
+97155 97131 2955264 /Users/x/.nvm/versions/node/v24.18.0/bin/node /repo/node_modules/next/dist/compiled/jest-worker/processChild.js
+`;
+
+describe("parseProcessTable", () => {
+  it("reads pid, parent and command from real ps output", () => {
+    const rows = parseProcessTable(REAL_PS_OUTPUT);
+    const worker = rows.find((row) => row.pid === 97155);
+
+    expect(worker?.ppid).toBe(97131);
+    expect(worker?.command).toContain("processChild.js");
+  });
+
+  it("converts ps kilobytes into bytes", () => {
+    const rows = parseProcessTable(REAL_PS_OUTPUT);
+    const worker = rows.find((row) => row.pid === 97155);
+
+    // 2955264 KB is the ~2.8 GiB the worker had reached before it died.
+    expect(worker?.rssBytes).toBe(2_955_264 * 1024);
+  });
+
+  it("skips the header instead of reading it as a process", () => {
+    const rows = parseProcessTable(REAL_PS_OUTPUT);
+    expect(rows.every((row) => Number.isInteger(row.pid))).toBe(true);
+    expect(rows).toHaveLength(5);
+  });
+
+  it("keeps commands that contain spaces whole", () => {
+    const rows = parseProcessTable(REAL_PS_OUTPUT);
+    expect(rows.find((row) => row.pid === 97107)?.command).toBe("npm run build");
+  });
+
+  it("skips malformed lines rather than failing the sample", () => {
+    const rows = parseProcessTable("  PID  PPID    RSS COMMAND\nnot a row at all\n42 1 100 node\n");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.pid).toBe(42);
+  });
+
+  it("returns nothing for empty output", () => {
+    expect(parseProcessTable("")).toEqual([]);
+  });
+});
+
+describe("descendantsOf", () => {
+  const rows = parseProcessTable(REAL_PS_OUTPUT);
+
+  it("finds a worker nested below the launched process", () => {
+    // Launching `npm run build` puts two processes between us and the worker.
+    const descendants = descendantsOf(rows, 97107).map((row) => row.pid);
+    expect(descendants).toContain(97131);
+    expect(descendants).toContain(97155);
+  });
+
+  it("excludes the root itself", () => {
+    expect(descendantsOf(rows, 97107).map((row) => row.pid)).not.toContain(97107);
+  });
+
+  it("returns nothing for a process with no children", () => {
+    expect(descendantsOf(rows, 97155)).toEqual([]);
+  });
+
+  it("does not walk upwards", () => {
+    expect(descendantsOf(rows, 97131).map((row) => row.pid)).toEqual([97155]);
+  });
+
+  it("survives a cycle in the table without hanging", () => {
+    // Not expected from a real kernel, but a self-parenting row must not spin.
+    const cyclic = parseProcessTable("10 11 100 a\n11 10 100 b\n");
+    expect(descendantsOf(cyclic, 10).map((row) => row.pid)).toEqual([11]);
+  });
+});
+
+describe("isStaticGenWorker", () => {
+  const rows = parseProcessTable(REAL_PS_OUTPUT);
+
+  it("recognises the jest-worker child Next spawns for static generation", () => {
+    const worker = rows.find((row) => row.pid === 97155);
+    expect(worker !== undefined && isStaticGenWorker(worker)).toBe(true);
+  });
+
+  it("does not mistake the build parent for a worker", () => {
+    // The parent sheds memory while the worker climbs: counting it as a worker
+    // would cancel the finding out.
+    const parent = rows.find((row) => row.pid === 97131);
+    expect(parent !== undefined && isStaticGenWorker(parent)).toBe(false);
+  });
+});

--- a/src/process-tree.ts
+++ b/src/process-tree.ts
@@ -1,0 +1,111 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+
+export type ProcessRow = {
+  pid: number;
+  ppid: number;
+  /** Resident set size in bytes. `ps` reports KB; converted once, here. */
+  rssBytes: number;
+  command: string;
+};
+
+/**
+ * A build's static-generation worker, as spawned by Next.
+ *
+ * Next runs these through jest-worker, and `experimental.workerThreads`
+ * defaults to false — so they are real child processes with their own PID and
+ * their own resident memory, which is the whole reason a build is measurable
+ * from outside without instrumenting anyone's code. A worker thread would have
+ * neither.
+ */
+const STATIC_WORKER_MARKER = "jest-worker/processChild";
+// Next vendors jest-worker, so the real command ends in
+// `next/dist/compiled/jest-worker/processChild.js` — matching the tail rather
+// than the full path keeps this working if the vendoring path moves again.
+
+const KB = 1024;
+
+/**
+ * Parses `ps -axo pid,ppid,rss,command` output.
+ *
+ * Columns are right-aligned to widths that vary with the values, and the
+ * command itself contains spaces — so the first three fields are split off and
+ * everything after them is the command. A line that does not start with three
+ * numbers is not a process row (the header, or a wrapped line) and is skipped
+ * rather than failing the sample.
+ */
+export function parseProcessTable(output: string): ProcessRow[] {
+  const rows: ProcessRow[] = [];
+  for (const line of output.split("\n")) {
+    const match = /^\s*(\d+)\s+(\d+)\s+(\d+)\s+(.+)$/.exec(line);
+    if (match === null) {
+      continue;
+    }
+    const [, pid, ppid, rssKb, command] = match;
+    if (pid === undefined || ppid === undefined || rssKb === undefined || command === undefined) {
+      continue;
+    }
+    rows.push({
+      pid: Number(pid),
+      ppid: Number(ppid),
+      rssBytes: Number(rssKb) * KB,
+      command,
+    });
+  }
+  return rows;
+}
+
+/**
+ * Every process below `rootPid`, at any depth, excluding the root itself.
+ *
+ * Walks generation by generation rather than recursing per row: a build tree is
+ * shallow but the machine's process table is not, and this visits each row once
+ * per generation instead of once per ancestor.
+ */
+export function descendantsOf(rows: readonly ProcessRow[], rootPid: number): ProcessRow[] {
+  const found = new Map<number, ProcessRow>();
+  let frontier = new Set<number>([rootPid]);
+  while (frontier.size > 0) {
+    const next = new Set<number>();
+    for (const row of rows) {
+      if (!frontier.has(row.ppid) || found.has(row.pid) || row.pid === rootPid) {
+        continue;
+      }
+      found.set(row.pid, row);
+      next.add(row.pid);
+    }
+    frontier = next;
+  }
+  return [...found.values()];
+}
+
+/** Whether a row is one of the build's static-generation workers. */
+export function isStaticGenWorker(row: ProcessRow): boolean {
+  return row.command.includes(STATIC_WORKER_MARKER);
+}
+
+export type ProcessTableSample =
+  | { ok: true; rows: ProcessRow[] }
+  | { ok: false; reason: string };
+
+/**
+ * One sample of the whole process table.
+ *
+ * The failure is reported rather than swallowed. An empty table and an
+ * unreadable one look identical downstream — both yield no workers — and
+ * reporting "nothing to measure" when the truth is "could not look" is the
+ * silent false negative this tool exists to avoid. Seen for real: a sandbox
+ * that denies `ps` turned a leaking build into a clean run.
+ */
+export async function sampleProcessTable(): Promise<ProcessTableSample> {
+  try {
+    const { stdout } = await run("ps", ["-axo", "pid,ppid,rss,command"], {
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    return { ok: true, rows: parseProcessTable(stdout) };
+  } catch (cause) {
+    return { ok: false, reason: cause instanceof Error ? cause.message : String(cause) };
+  }
+}

--- a/src/report.test.ts
+++ b/src/report.test.ts
@@ -417,3 +417,38 @@ describe("formatReport carries the load-failure diagnosis", () => {
     expect(output).toContain("--connections (currently 5)");
   });
 });
+
+// A listing of six routes where four were skipped reads, at a glance, like an
+// app that was measured.
+describe("formatReport coverage", () => {
+  it("states how much of the app the run actually covered", () => {
+    // The fixture has two measured routes, one skipped and one failed.
+    const output = formatReport(makeRunReport());
+
+    expect(output).toContain("measured 2 of 4 discovered route(s)");
+    expect(output).toContain("1 skipped");
+    expect(output).toContain("1 failed");
+    expect(output).toContain("not a verdict about your app");
+  });
+
+  it("counts routes that were reachable but not exercised", () => {
+    const report = makeRunReport();
+    report.routes = [
+      ...report.routes,
+      { route: "/isr", status: "not-exercised", reason: "revalidates every 3600s" },
+    ];
+    const output = formatReport(report);
+
+    expect(output).toContain("measured 2 of 5 discovered route(s)");
+    expect(output).toContain("1 not exercised");
+  });
+
+  it("says so plainly when everything was measured", () => {
+    const report = makeRunReport();
+    report.routes = report.routes.filter((route) => route.status === "measured");
+    const output = formatReport(report);
+
+    expect(output).toContain("measured all 2 discovered route(s)");
+    expect(output).not.toContain("not a verdict");
+  });
+});

--- a/src/report.test.ts
+++ b/src/report.test.ts
@@ -396,3 +396,24 @@ describe("formatReport guidance for skipped routes", () => {
     expect(formatReport(report)).not.toContain("need sample params");
   });
 });
+
+describe("formatReport carries the load-failure diagnosis", () => {
+  it("shows the whole reason, including which knob to reach for", () => {
+    const report = makeRunReport();
+    report.routes = [
+      {
+        route: "/p/[slug]",
+        status: "failed",
+        reason:
+          "103 of 300 requests failed against http://127.0.0.1:9/p/1 (0 non-2xx, 70 errors, " +
+          "70 timeouts) — the failures are timeouts rather than error responses, so the load " +
+          "may simply be more than the app or something it calls can serve; lower " +
+          "--connections (currently 5) and re-run before concluding anything about memory",
+      },
+    ];
+    const output = formatReport(report);
+
+    expect(output).toContain("timeouts rather than error responses");
+    expect(output).toContain("--connections (currently 5)");
+  });
+});

--- a/src/report.test.ts
+++ b/src/report.test.ts
@@ -156,10 +156,12 @@ describe("formatReport numeric fidelity", () => {
     expect(output).not.toContain("] D ");
   });
 
-  it("renders every non-measured route exactly once", () => {
-    const output = formatReport(makeRunReport());
-    expect(output.split("\n").filter((line) => line.includes("/products/[id]"))).toHaveLength(1);
-    expect(output.split("\n").filter((line) => line.includes("/broken"))).toHaveLength(1);
+  it("renders every non-measured route exactly once in the listing", () => {
+    // A skipped route also appears in the config skeleton below the listing;
+    // that is a second mention on purpose, not a duplicated row.
+    const lines = formatReport(makeRunReport()).split("\n");
+    expect(lines.filter((line) => line.includes("skipped:") && line.includes("/products/[id]"))).toHaveLength(1);
+    expect(lines.filter((line) => line.includes("/broken"))).toHaveLength(1);
   });
 });
 
@@ -361,5 +363,36 @@ describe("formatReport for ISR routes driven through revalidation", () => {
 
   it("says nothing for a route that is not ISR", () => {
     expect(formatReport(makeRunReport())).not.toContain("ISR revalidation");
+  });
+});
+
+// Telling someone a config file exists and leaving them to work out its shape
+// is the difference between a run they fix in ten seconds and one they abandon.
+describe("formatReport guidance for skipped routes", () => {
+  it("prints the config that would measure them", () => {
+    const output = formatReport(makeRunReport());
+
+    expect(output).toContain("need sample params");
+    expect(output).toContain("next-leak.config.json");
+    expect(output).toContain('"/products/[id]"');
+    expect(output).toContain("REPLACE-ME");
+  });
+
+  it("uses values the build already prerendered when it knows them", () => {
+    const report = makeRunReport();
+    report.prerender = {
+      routes: { "/products/widget-1": { initialRevalidateSeconds: 60, srcRoute: "/products/[id]" } },
+    };
+    const output = formatReport(report);
+
+    expect(output).toContain("widget-1");
+    expect(output).toContain("already prerendered");
+    expect(output).not.toContain("REPLACE-ME");
+  });
+
+  it("says nothing when no route needs configuring", () => {
+    const report = makeRunReport();
+    report.routes = report.routes.filter((route) => route.status !== "skipped");
+    expect(formatReport(report)).not.toContain("need sample params");
   });
 });

--- a/src/report.test.ts
+++ b/src/report.test.ts
@@ -321,3 +321,45 @@ describe("formatReport confidence", () => {
     expect(output).toContain("--routes /leaky");
   });
 });
+
+// An ISR route serves its cache unless the request carries the build's own
+// revalidation header. Measured on vercel/next.js#96533: the same app reports
+// `leak` with that header and `stable` without it — so a route the run could
+// not drive must never be presented as healthy.
+describe("formatReport for routes that were not exercised", () => {
+  it("says not exercised, never stable", () => {
+    const report = makeRunReport();
+    report.routes = [
+      {
+        route: "/posts/[slug]",
+        status: "not-exercised",
+        reason:
+          "revalidates every 3600s, but the build's prerender-manifest.json carries no previewModeId",
+      },
+    ];
+    const output = formatReport(report);
+
+    expect(output).toContain("/posts/[slug]  not exercised:");
+    expect(output).toContain("3600s");
+    expect(output).not.toContain("stable");
+  });
+});
+
+describe("formatReport for ISR routes driven through revalidation", () => {
+  it("says the route was driven, and how often it revalidates", () => {
+    // Without this line a reader cannot tell a curve measured against a
+    // re-render from one measured against a static cache.
+    const report = makeRunReport();
+    const route = report.routes[0];
+    if (route?.status !== "measured") throw new Error("fixture broken");
+    route.revalidatedEverySeconds = 3600;
+    const output = formatReport(report);
+
+    expect(output).toContain("driven through ISR revalidation");
+    expect(output).toContain("revalidates every 3600s");
+  });
+
+  it("says nothing for a route that is not ISR", () => {
+    expect(formatReport(makeRunReport())).not.toContain("ISR revalidation");
+  });
+});

--- a/src/report.test.ts
+++ b/src/report.test.ts
@@ -97,6 +97,32 @@ describe("formatReport", () => {
   it("says nothing about peaks on a proportionate route", () => {
     expect(formatReport(makeRunReport())).not.toContain("peak pressure");
   });
+
+  it("reports unreclaimed retention beside a stable verdict", () => {
+    // The vercel/next.js#96533 shape: climbs before collection, flat after —
+    // a forced GC takes it back, a production process may never run one.
+    const report = makeRunReport();
+    const healthy = report.routes[0];
+    if (healthy?.status !== "measured") {
+      throw new Error("fixture broken");
+    }
+    healthy.unreclaimedTrend = {
+      verdict: "leak",
+      growthPerCycle: 10 * MB,
+      deltas: [10 * MB, 10 * MB],
+      source: "external",
+    };
+    const output = formatReport(report);
+
+    expect(output).toContain("stable");
+    expect(output).toContain("unreclaimed");
+    expect(output).toContain("external memory");
+    expect(output).toContain("2.00 MB/1000 req");
+  });
+
+  it("says nothing about unreclaimed memory on a route that is flat both ways", () => {
+    expect(formatReport(makeRunReport())).not.toContain("unreclaimed");
+  });
 });
 
 // Renderer regressions: the mutation run showed the report bodies were only

--- a/src/report.test.ts
+++ b/src/report.test.ts
@@ -99,25 +99,33 @@ describe("formatReport", () => {
   });
 
   it("reports unreclaimed retention beside a stable verdict", () => {
-    // The vercel/next.js#96533 shape: climbs before collection, flat after —
-    // a forced GC takes it back, a production process may never run one.
+    // The vercel/next.js#96533 shape, measured 2026-08-18: arrayBuffers held
+    // between collections against a flat 0.32 MB after one. The pre-collection
+    // series does not climb — the gap is the finding.
     const report = makeRunReport();
     const healthy = report.routes[0];
     if (healthy?.status !== "measured") {
       throw new Error("fixture broken");
     }
-    healthy.unreclaimedTrend = {
-      verdict: "leak",
-      growthPerCycle: 10 * MB,
-      deltas: [10 * MB, 10 * MB],
-      source: "external",
-    };
+    const held = [4.11, 0.32, 5.03, 4.44, 3.35, 5.72];
+    healthy.unreclaimedSamples = held.map((mb) => ({
+      gcExposed: true,
+      heapUsed: 40 * MB,
+      rss: 190 * MB,
+      external: mb * MB,
+      arrayBuffers: mb * MB,
+    }));
+    healthy.memorySamples = healthy.memorySamples.map((sample) => ({
+      ...sample,
+      external: 0.32 * MB,
+      arrayBuffers: 0.32 * MB,
+    }));
     const output = formatReport(report);
 
     expect(output).toContain("stable");
     expect(output).toContain("unreclaimed");
-    expect(output).toContain("external memory");
-    expect(output).toContain("2.00 MB/1000 req");
+    expect(output).toContain("arrayBuffers");
+    expect(output).toContain("what it retains");
   });
 
   it("says nothing about unreclaimed memory on a route that is flat both ways", () => {

--- a/src/report.ts
+++ b/src/report.ts
@@ -1,8 +1,12 @@
 import type { FindingAttribution } from "./attribution.js";
 import type { HeapSample } from "./control-server.js";
-import { classifyTrend } from "./trend.js";
+import { classifyTrend, type TrendVerdict } from "./trend.js";
 import { effectiveVerdict, resolveCycles } from "./confidence.js";
 import { assessPeakPressure, describePeakPressure } from "./peak-pressure.js";
+import {
+  assessUnreclaimedRetention,
+  describeUnreclaimedRetention,
+} from "./unreclaimed-retention.js";
 import type { RouteReport, RunParameters, RunReport } from "./runner.js";
 
 type MeasuredRouteView = Extract<RouteReport, { status: "measured" }>;
@@ -143,6 +147,22 @@ function peakPressureLines(route: MeasuredRouteView, parameters: RunParameters):
   return pressure === null ? [] : [`      ▲ peak pressure: ${describePeakPressure(pressure)}`];
 }
 
+/**
+ * Memory held before collection is a third question again — not what survives
+ * a GC, and not what the process reached under load, but what it is sitting on
+ * between collections. Reported next to the verdict for the same reason.
+ */
+function unreclaimedLines(route: MeasuredRouteView, verdict: TrendVerdict): string[] {
+  const retention = assessUnreclaimedRetention({
+    unreclaimedTrend: route.unreclaimedTrend,
+    verdict,
+    requestsPerCycle: route.requestsPerCycle,
+  });
+  return retention === null
+    ? []
+    : [`      ▲ unreclaimed: ${describeUnreclaimedRetention(retention)}`];
+}
+
 function routeLines(route: RouteReport, parameters: RunParameters): string[] {
   if (route.status === "skipped") {
     return [`  – ${route.route}  skipped: ${route.reason}`];
@@ -166,6 +186,7 @@ function routeLines(route: RouteReport, parameters: RunParameters): string[] {
     ...confidenceLines(route),
     ...memorySourceLines(route, verdict),
     ...peakPressureLines(route, parameters),
+    ...unreclaimedLines(route, verdict),
     ...findingLines(route),
   ];
 }

--- a/src/report.ts
+++ b/src/report.ts
@@ -1,7 +1,7 @@
 import type { FindingAttribution } from "./attribution.js";
 import type { HeapSample } from "./control-server.js";
 import { classifyTrend, type TrendVerdict } from "./trend.js";
-import { effectiveVerdict, resolveCycles } from "./confidence.js";
+import { effectiveVerdict, resolveCycles, warrantsIssueDraft } from "./confidence.js";
 import { assessPeakPressure, describePeakPressure } from "./peak-pressure.js";
 import {
   assessUnreclaimedRetention,
@@ -154,9 +154,10 @@ function peakPressureLines(route: MeasuredRouteView, parameters: RunParameters):
  */
 function unreclaimedLines(route: MeasuredRouteView, verdict: TrendVerdict): string[] {
   const retention = assessUnreclaimedRetention({
-    unreclaimedTrend: route.unreclaimedTrend,
+    unreclaimedSamples: route.unreclaimedSamples,
+    memorySamples: route.memorySamples,
     verdict,
-    requestsPerCycle: route.requestsPerCycle,
+    verdictIsWellSupported: warrantsIssueDraft(route),
   });
   return retention === null
     ? []

--- a/src/report.ts
+++ b/src/report.ts
@@ -242,6 +242,30 @@ function skippedGuidanceLines(report: RunReport): string[] {
   ];
 }
 
+/**
+ * How much of the app the run actually covered.
+ *
+ * A listing of six routes where four were skipped reads, at a glance, like an
+ * app that was measured. It was not, and the difference between "your app is
+ * fine" and "we looked at a third of it" is the whole value of the number.
+ */
+function coverageLine(report: RunReport): string {
+  const total = report.routes.length;
+  const measured = report.routes.filter((route) => route.status === "measured").length;
+  if (measured === total) {
+    return `measured all ${total} discovered route(s)`;
+  }
+  const breakdown = (["skipped", "not-exercised", "failed"] as const)
+    .map((status) => ({
+      status,
+      count: report.routes.filter((route) => route.status === status).length,
+    }))
+    .filter((entry) => entry.count > 0)
+    .map((entry) => `${entry.count} ${entry.status.replace("-", " ")}`)
+    .join(", ");
+  return `measured ${measured} of ${total} discovered route(s) — ${breakdown}; the rest is not a verdict about your app`;
+}
+
 export function formatReport(report: RunReport): string {
   const lines = [`next-leak — ${report.appDir}`, ""];
   for (const route of report.routes) {
@@ -266,8 +290,8 @@ export function formatReport(report: RunReport): string {
     resolvedCycles.length === 0
       ? `${cycles} cycles`
       : `${cycles} cycles (${resolvedCycles.join(", ")} where resolved)`;
+  lines.push("", coverageLine(report));
   lines.push(
-    "",
     `judged over ${cyclesLabel} × ${loadRequests} requests, growth gate ` +
       `${(minGrowthPerCycle / 1024).toFixed(0)} KiB/cycle ` +
       `(${formatGrowth((minGrowthPerCycle / loadRequests) * 1000)}), heap cap ${maxOldSpaceMb} MB`,

--- a/src/report.ts
+++ b/src/report.ts
@@ -56,6 +56,21 @@ function ownerLabel(attribution: FindingAttribution): string | null {
   }
 }
 
+/**
+ * An ISR route serves its cache unless the load carries the build's own
+ * revalidation header. Saying so distinguishes a curve measured against a
+ * re-render from one measured against a static file — the difference between a
+ * verdict and a flat line that means nothing.
+ */
+function revalidationLines(route: MeasuredRouteView): string[] {
+  return route.revalidatedEverySeconds === undefined
+    ? []
+    : [
+        `      driven through ISR revalidation (revalidates every ` +
+          `${route.revalidatedEverySeconds}s; without it the load would serve the cache)`,
+      ];
+}
+
 function confidenceLines(route: MeasuredRouteView): string[] {
   const lines: string[] = [];
   // What the instrument thinks of its own reading. Silence here would be the
@@ -171,6 +186,11 @@ function routeLines(route: RouteReport, parameters: RunParameters): string[] {
   if (route.status === "failed") {
     return [`  ✖ ${route.route}  failed: ${route.reason}`];
   }
+  // Deliberately not `stable`: the load could not have exercised this route, so
+  // the flat curve it would have produced says nothing about the app.
+  if (route.status === "not-exercised") {
+    return [`  – ${route.route}  not exercised: ${route.reason}`];
+  }
 
   const verdict = effectiveVerdict(route);
   const curve = route.samples.map(formatMb).join(" → ");
@@ -184,6 +204,7 @@ function routeLines(route: RouteReport, parameters: RunParameters): string[] {
     `  ${VERDICT_ICON[verdict]} ${route.route}  ${verdict}  (${formatGrowth(
       route.growthPer1000Requests
     )})  heap ${curve}${resolved}`,
+    ...revalidationLines(route),
     ...confidenceLines(route),
     ...memorySourceLines(route, verdict),
     ...peakPressureLines(route, parameters),

--- a/src/report.ts
+++ b/src/report.ts
@@ -3,6 +3,7 @@ import type { HeapSample } from "./control-server.js";
 import { classifyTrend, type TrendVerdict } from "./trend.js";
 import { effectiveVerdict, resolveCycles, warrantsIssueDraft } from "./confidence.js";
 import { assessPeakPressure, describePeakPressure } from "./peak-pressure.js";
+import { hasPlaceholders, renderConfigSkeleton } from "./route-guidance.js";
 import {
   assessUnreclaimedRetention,
   describeUnreclaimedRetention,
@@ -214,11 +215,39 @@ function routeLines(route: RouteReport, parameters: RunParameters): string[] {
 }
 
 /** Renders the terminal report. Pure: no I/O, no colors, stable output. */
+/**
+ * The config that would measure the routes this run had to skip.
+ *
+ * Naming a file and leaving the reader to work out its shape is the difference
+ * between a run they fix in ten seconds and one they abandon. Values come from
+ * the build's own prerendered paths where it knows them, so the fragment often
+ * needs no editing at all.
+ */
+function skippedGuidanceLines(report: RunReport): string[] {
+  const needConfig = report.routes
+    .filter((route) => route.status === "skipped" && route.reason.includes("sample params"))
+    .map((route) => route.route);
+  const skeleton = renderConfigSkeleton(needConfig, report.prerender);
+  if (skeleton === null) {
+    return [];
+  }
+  const editing = hasPlaceholders(skeleton)
+    ? ` Replace each ${"REPLACE-ME"} with a value that exists in your app.`
+    : ` The values come from paths your build already prerendered.`;
+  return [
+    "",
+    `${needConfig.length} route(s) need sample params. Write this to ` +
+      `next-leak.config.json in the app directory:${editing}`,
+    ...skeleton.split("\n").map((line) => `  ${line}`),
+  ];
+}
+
 export function formatReport(report: RunReport): string {
   const lines = [`next-leak — ${report.appDir}`, ""];
   for (const route of report.routes) {
     lines.push(...routeLines(route, report.parameters));
   }
+  lines.push(...skippedGuidanceLines(report));
   // A verdict whose gate is not printed cannot be reproduced: the same route
   // judged against a different threshold is a different measurement.
   const { minGrowthPerCycle, loadRequests, cycles, maxOldSpaceMb } = report.parameters;

--- a/src/ritual.test.ts
+++ b/src/ritual.test.ts
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { requestMemory } from "./control-client.js";
 import type { LaunchedApp } from "./launcher.js";
 import type { LoadPhaseResult } from "./load.js";
-import { runRitual, type RitualDeps } from "./ritual.js";
+import { runRitual, unreclaimedSettleFor, type RitualDeps } from "./ritual.js";
 
 const MB = 1024 * 1024;
 
@@ -178,11 +178,17 @@ describe("runRitual", () => {
     expect(shape[1]).toBe("snapshot:baseline");
     expect(shape.filter((event) => event === "load:5000")).toHaveLength(4);
     expect(shape.at(-1)).toBe("snapshot:after");
-    // At least one forced GC between each load and its sample.
+    // Every cycle's sample is preceded by a forced collection: a `gc` for the
+    // intermediate cycles, the after-snapshot for the last one. Asserted over
+    // the whole span to the next load rather than a fixed-width window, so
+    // adding a phase inside the cycle cannot silently void the check.
     for (const [index, event] of shape.entries()) {
-      if (event === "load:5000") {
-        expect(shape.slice(index + 1, index + 3)).toContain("gc");
+      if (event !== "load:5000") {
+        continue;
       }
+      const nextLoad = shape.findIndex((later, at) => at > index && later === "load:5000");
+      const cycle = shape.slice(index + 1, nextLoad === -1 ? undefined : nextLoad);
+      expect(cycle.some((phase) => phase === "gc" || phase === "snapshot:after")).toBe(true);
     }
     expect(result.samples).toEqual([29 * MB, 31 * MB, 33 * MB, 35 * MB, 37 * MB]);
     expect(result.trend.verdict).toBe("leak");
@@ -473,10 +479,13 @@ describe("mutation-hardening: ritual", () => {
       "warm-up",
       "baseline snapshot",
       "cycle 1 load",
+      "cycle 1 unreclaimed read",
       "cycle 1 settle",
       "cycle 2 load",
+      "cycle 2 unreclaimed read",
       "cycle 2 settle",
       "cycle 3 load",
+      "cycle 3 unreclaimed read",
       "cycle 3 settle",
       "after snapshot",
     ]);
@@ -485,6 +494,64 @@ describe("mutation-hardening: ritual", () => {
       "cycle 2",
       "cycle 3",
     ]);
+  });
+});
+
+// Every other number in a run is post-GC, which is what makes the verdict
+// mean something and is also blind to memory a full GC would reclaim that a
+// production process never runs one often enough to (vercel/next.js#96533).
+describe("unreclaimed retention", () => {
+  it("caps the pre-collection wait at a quarter of the idle", () => {
+    // --quick idles for 8s: a flat 2s wait would be a quarter of its budget,
+    // and anything shorter must scale down rather than eat the settle.
+    expect(unreclaimedSettleFor(30_000)).toBe(2000);
+    expect(unreclaimedSettleFor(8000)).toBe(2000);
+    expect(unreclaimedSettleFor(4000)).toBe(1000);
+    expect(unreclaimedSettleFor(0)).toBe(0);
+  });
+
+  it("records one pre-collection reading per cycle", async () => {
+    harness = await makeHarness([29 * MB, 30 * MB, 31 * MB, 32 * MB]);
+    const result = await runRitual({ ...(await baseOptions()), cycles: 3 }, harness.deps);
+
+    expect(result.unreclaimedSamples).toHaveLength(3);
+    expect(result.samples).toHaveLength(4); // baseline + 3 cycles, unchanged
+  });
+
+  it("waits idle/4 before the reading and hands the rest to the settle", async () => {
+    harness = await makeHarness([29 * MB, 30 * MB, 31 * MB, 32 * MB]);
+    await runRitual({ ...(await baseOptions()), cycles: 3, idleMs: 4000 }, harness.deps);
+
+    // Sleeps here are fake and instant, so their sum is not wall clock and
+    // cannot show the total idle. What it does show is the shape: each cycle
+    // opens its idle with the 1000 ms pre-collection wait (4000 / 4) before
+    // the first `mem`, and the settle that follows never blocks longer than
+    // one poll.
+    const idle = harness.events.filter(
+      (event) => event === "mem" || event === "gc" || event.startsWith("sleep:")
+    );
+    const firstCycle = idle.slice(idle.indexOf("sleep:1000"));
+
+    expect(firstCycle[0]).toBe("sleep:1000");
+    expect(firstCycle[1]).toBe("mem");
+    expect(
+      idle
+        .filter((event) => event.startsWith("sleep:"))
+        .map((event) => Number(event.split(":")[1]))
+        .every((ms) => ms <= 2000)
+    ).toBe(true);
+  });
+
+  it("drops the whole series when a reading is lost", async () => {
+    // A hole makes every later delta span two cycles instead of one, so a
+    // partial series is worse than none. The verdict must survive it.
+    harness = await makeHarness([29 * MB, 30 * MB, 31 * MB, 32 * MB], { failMemory: true });
+    const result = await runRitual({ ...(await baseOptions()), cycles: 3 }, harness.deps);
+
+    expect(result.unreclaimedSamples).toEqual([]);
+    expect(result.unreclaimedTrend.verdict).toBe("inconclusive");
+    expect(result.samples).toHaveLength(4);
+    expect(result.trend.verdict).toBeDefined();
   });
 });
 

--- a/src/ritual.ts
+++ b/src/ritual.ts
@@ -101,6 +101,21 @@ export type RitualResult = {
   memorySamples: HeapSample[];
   /** Highest memory seen during each load cycle, sampled without collecting. */
   peaks: PeakSample[];
+  /**
+   * One reading per cycle taken before any collection is forced — what the
+   * process is holding on its own.
+   *
+   * Every other number here is post-GC, which is what makes a verdict mean
+   * something and is also blind to a whole class of leak: memory a full GC
+   * would reclaim that a production process never runs one often enough to
+   * (vercel/next.js#96533). Absolute values overstate retention — this is
+   * taken seconds after load, not hours, so it includes garbage not yet
+   * collected — but a roughly constant offset across identical cycles cancels
+   * out of the deltas the trend is read from.
+   */
+  unreclaimedSamples: HeapSample[];
+  /** Trend over `unreclaimedSamples`. Reported, never the verdict. */
+  unreclaimedTrend: TrendResult;
   baselineSnapshot: string;
   afterSnapshot: string;
   trend: TrendResult;
@@ -132,6 +147,28 @@ const SETTLE_TOLERANCE = 0.01;
  * port from the app, so the measured request path never sees them.
  */
 const PEAK_POLL_MS = 250;
+
+/**
+ * How long to let a cycle settle before reading memory without collecting.
+ *
+ * Reading the instant load stops catches the heap at its most volatile —
+ * in-flight buffers, possibly a collection already under way — and the
+ * cycle-to-cycle variance would swamp the trend this reading exists to show.
+ *
+ * One settle poll, deliberately: nothing in this ritual sleeps longer than
+ * `SETTLE_POLL_MS` in one go, so a run stays responsive to Ctrl+C.
+ */
+const UNRECLAIMED_SETTLE_MS = SETTLE_POLL_MS;
+
+/**
+ * The pre-collection wait, taken *out of* the idle rather than added to it.
+ *
+ * Capped at a quarter of the idle so short profiles keep their settle budget:
+ * `--quick` idles for 8 s, and a flat 3 s would be nearly half of it.
+ */
+export function unreclaimedSettleFor(idleMs: number): number {
+  return Math.min(UNRECLAIMED_SETTLE_MS, Math.floor(idleMs / 4));
+}
 
 /**
  * Polls the measured process while a load phase runs, keeping the maximum of
@@ -357,6 +394,8 @@ export async function runRitual(
     );
 
     const memorySamples: HeapSample[] = [baseline.sample];
+    const unreclaimedSamples: HeapSample[] = [];
+    let unreclaimedLost = false;
     const peaks: PeakSample[] = [];
     let afterSnapshot = "";
     for (let cycle = 1; cycle <= cycles; cycle += 1) {
@@ -370,8 +409,26 @@ export async function runRitual(
           peaks.push(await poller.stop());
         }
       });
+      // Read what the process holds before anything is collected. The wait
+      // comes out of the idle below, not on top of it: `waitUntilSettled`
+      // forces a GC on every poll, so this is the only point in the cycle
+      // where the process can be observed holding its own memory.
+      const unreclaimedSettleMs = unreclaimedSettleFor(idleMs);
+      await timed(`cycle ${cycle} unreclaimed read`, async () => {
+        await deps.sleep(unreclaimedSettleMs);
+        try {
+          unreclaimedSamples.push(await deps.readMemory(app.controlPort));
+        } catch {
+          // A missed reading leaves a hole, and a hole makes every later delta
+          // span two cycles instead of one. Drop the series rather than report
+          // a trend over it; the verdict does not depend on it, and if the app
+          // is actually gone the post-GC sample below says so properly.
+          unreclaimedLost = true;
+        }
+      });
+
       const settle = await timed(`cycle ${cycle} settle`, () =>
-        waitUntilSettled(app.controlPort, idleMs, deps)
+        waitUntilSettled(app.controlPort, idleMs - unreclaimedSettleMs, deps)
       );
       settleOutcomes.push({ phase: `cycle ${cycle}`, ...settle });
 
@@ -400,6 +457,16 @@ export async function runRitual(
       samples,
       memorySamples,
       peaks,
+      unreclaimedSamples: unreclaimedLost ? [] : unreclaimedSamples,
+      // The first cycle plays the part the baseline plays for the post-GC
+      // series, so both trends drop a warm-up delta and stay comparable.
+      unreclaimedTrend: unreclaimedLost
+        ? { verdict: "inconclusive", growthPerCycle: 0, deltas: [] }
+        : classifyMemoryTrend(
+            unreclaimedSamples.map((sample) => sample.heapUsed),
+            unreclaimedSamples.map((sample) => sample.external),
+            { minGrowthPerCycle }
+          ),
       baselineSnapshot: baseline.file,
       afterSnapshot,
       trend: classifyMemoryTrend(samples, externalSamples, { minGrowthPerCycle }),

--- a/src/route-config.test.ts
+++ b/src/route-config.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  boundedMarkerOf,
   loadRouteConfig,
   resolveRoutePath,
   ROUTE_CONFIG_FILE,
@@ -129,5 +130,45 @@ describe("query strings and client abandonment", () => {
     expect((await loadRouteConfig(dir)).abandonAfterMs).toBe(50);
     await writeFile(path.join(dir, ROUTE_CONFIG_FILE), JSON.stringify({ abandonAfterMs: -5 }));
     await expect(loadRouteConfig(dir)).rejects.toBeInstanceOf(RouteConfigError);
+  });
+});
+
+// `{n}` is unbounded by construction; the reported leaks turn on a fixed set of
+// keys revisited instead — #96533 revalidates the same 200 posts over and over.
+describe("bounded cardinality marker", () => {
+  it("reads the bound out of a sample value", () => {
+    expect(boundedMarkerOf("post-{n%200}")).toEqual({ marker: "{n%200}", bound: 200 });
+  });
+
+  it("reads nothing from an unbounded value", () => {
+    expect(boundedMarkerOf("post-{n}")).toBeNull();
+    expect(boundedMarkerOf("post-1")).toBeNull();
+  });
+
+  it("ignores a bound that is not a positive integer", () => {
+    expect(boundedMarkerOf("post-{n%0}")).toBeNull();
+  });
+
+  it("survives the percent-encoding that resolution applies", () => {
+    // encodeURIComponent turns `{n%5}` into `%7Bn%255%7D`; if that reached the
+    // load phase every request would hit the same literal path.
+    const resolved = resolveRoutePath("/posts/[slug]", {
+      routes: { "/posts/[slug]": { slug: "post-{n%5}" } },
+    });
+
+    expect(resolved).toBe("/posts/post-{n%5}");
+  });
+
+  it("rejects a value carrying both markers, before any measurement starts", async () => {
+    // Silently preferring one would make the run measure a cardinality nobody
+    // asked for, and cardinality is exactly what these leaks turn on.
+    const dir = await mkdtemp(path.join(tmpdir(), "next-leak-cfg-"));
+    await writeFile(
+      path.join(dir, ROUTE_CONFIG_FILE),
+      JSON.stringify({ params: { slug: "post-{n}-{n%10}" } })
+    );
+
+    await expect(loadRouteConfig(dir)).rejects.toBeInstanceOf(RouteConfigError);
+    await expect(loadRouteConfig(dir)).rejects.toThrow(/cannot carry both/);
   });
 });

--- a/src/route-config.ts
+++ b/src/route-config.ts
@@ -7,10 +7,21 @@ import { z } from "zod";
  * route params. `params` applies globally; `routes` overrides per route
  * template (keys as discovered, e.g. `/[lang]/candidate/[candidateId]`).
  */
+/**
+ * A sample value may carry `{n}` (a fresh value per request) or `{n%N}` (N
+ * distinct values, revisited) — never both. Silently preferring one would make
+ * the run measure a cardinality nobody asked for, and cardinality is precisely
+ * what these leaks turn on.
+ */
+const sampleValueSchema = z.string().refine(
+  (value) => !(value.includes("{n}") && /\{n%\d+\}/.test(value)),
+  { message: 'a sample value cannot carry both "{n}" and "{n%N}" — pick one' }
+);
+
 const routeConfigSchema = z
   .object({
-    params: z.record(z.string(), z.string()).optional(),
-    routes: z.record(z.string(), z.record(z.string(), z.string())).optional(),
+    params: z.record(z.string(), sampleValueSchema).optional(),
+    routes: z.record(z.string(), z.record(z.string(), sampleValueSchema)).optional(),
     /**
      * Headers sent with every request. Real traffic is not header-less:
      * compression (`Accept-Encoding`), sessions and auth change which code
@@ -103,11 +114,42 @@ export function dynamicSegmentsOf(routeTemplate: string): DynamicSegment[] {
  * with unique tails) are invisible when every request hits the same path.
  */
 export const UNIQUE_MARKER = "{n}";
+
+/**
+ * `{n%200}` — cycle through exactly 200 distinct values, revisiting them.
+ *
+ * `{n}` gives every request its own URL, which is the shape of bot traffic and
+ * of a cache that never repeats a key. It is not the shape the reported leaks
+ * have: vercel/next.js#96533 revalidates a fixed set of 200 posts over and over,
+ * and #92287 turns on how many distinct keys a cache holds at once. A bound is
+ * the difference between filling a cache and growing one without limit.
+ */
+const BOUNDED_MARKER = /\{n%(\d+)\}/;
+
+/** The bound in a sample value, or null when it carries none. */
+export function boundedMarkerOf(value: string): { marker: string; bound: number } | null {
+  const match = BOUNDED_MARKER.exec(value);
+  const bound = Number(match?.[1]);
+  if (match === null || !Number.isInteger(bound) || bound <= 0) {
+    return null;
+  }
+  return { marker: match[0], bound };
+}
 const ENCODED_MARKER = encodeURIComponent(UNIQUE_MARKER);
 
-/** Catch-all values may span segments, so `/` survives; everything else is escaped. */
+/**
+ * Catch-all values may span segments, so `/` survives; everything else is
+ * escaped — except the load markers, which must reach the load phase intact.
+ * `encodeURIComponent("{n%5}")` is `%7Bn%255%7D`, so the bounded marker needs
+ * restoring too, or the app receives a literal path with a percent-escape in it
+ * and every request lands on the same URL.
+ */
 const encodeSegment = (value: string): string =>
-  encodeURIComponent(value).split(ENCODED_MARKER).join(UNIQUE_MARKER);
+  restoreMarkers(encodeURIComponent(value).split(ENCODED_MARKER).join(UNIQUE_MARKER));
+
+const ENCODED_BOUNDED = /%7Bn%25(\d+)%7D/gi;
+const restoreMarkers = (value: string): string =>
+  value.replace(ENCODED_BOUNDED, (_match, bound: string) => `{n%${bound}}`);
 const encodeCatchAll = (value: string): string => value.split("/").map(encodeSegment).join("/");
 
 /**

--- a/src/route-config.ts
+++ b/src/route-config.ts
@@ -67,6 +67,36 @@ export async function loadRouteConfig(appDir: string): Promise<RouteConfig> {
 
 const SEGMENT_PATTERN = /^\[(\[)?(\.\.\.)?([^\]]+?)\]?\]$/;
 
+export type DynamicSegment = {
+  name: string;
+  /** `[...slug]` — the value may span several path segments. */
+  catchAll: boolean;
+  /** `[[...slug]]` — the segment can be omitted entirely. */
+  optional: boolean;
+};
+
+/**
+ * The dynamic segments of a route template, in order.
+ *
+ * Exported so guidance and resolution read the same grammar: a skeleton that
+ * named parameters the resolver does not recognise would be worse than none.
+ */
+export function dynamicSegmentsOf(routeTemplate: string): DynamicSegment[] {
+  const segments: DynamicSegment[] = [];
+  for (const segment of routeTemplate.split("/")) {
+    const match = SEGMENT_PATTERN.exec(segment);
+    if (match === null) {
+      continue;
+    }
+    segments.push({
+      name: match[3] ?? "",
+      catchAll: match[2] !== undefined,
+      optional: match[1] !== undefined,
+    });
+  }
+  return segments;
+}
+
 /**
  * Sample values may contain `{n}`, which the load phase replaces with a
  * per-request counter. Leaks keyed by URL (route caches, LRUs, bot traffic

--- a/src/route-guidance.test.ts
+++ b/src/route-guidance.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { hasPlaceholders, renderConfigSkeleton, sampleValuesFromManifest } from "./route-guidance.js";
+import { prerenderManifestSchema } from "./manifests.js";
+
+// The real shape of the vercel/next.js#96533 build: concrete paths pointing
+// back at their template through srcRoute.
+const MANIFEST = prerenderManifestSchema.parse({
+  routes: {
+    "/posts/post-0": { initialRevalidateSeconds: 3600, srcRoute: "/posts/[slug]" },
+    "/posts/post-1": { initialRevalidateSeconds: 3600, srcRoute: "/posts/[slug]" },
+    "/docs/a/b": { initialRevalidateSeconds: 60, srcRoute: "/docs/[...path]" },
+  },
+  preview: { previewModeId: "x" },
+});
+
+describe("sampleValuesFromManifest", () => {
+  it("lifts a real value the build already prerendered", () => {
+    expect(sampleValuesFromManifest(MANIFEST, "/posts/[slug]")).toEqual({ slug: "post-0" });
+  });
+
+  it("gives a catch-all every remaining segment", () => {
+    expect(sampleValuesFromManifest(MANIFEST, "/docs/[...path]")).toEqual({ path: "a/b" });
+  });
+
+  it("returns nothing for a template the build did not prerender", () => {
+    expect(sampleValuesFromManifest(MANIFEST, "/users/[id]")).toBeNull();
+  });
+
+  it("returns nothing without a manifest", () => {
+    expect(sampleValuesFromManifest(undefined, "/posts/[slug]")).toBeNull();
+  });
+});
+
+describe("renderConfigSkeleton", () => {
+  it("writes a config that resolves on the first try when the build knows a value", () => {
+    const skeleton = renderConfigSkeleton(["/posts/[slug]"], MANIFEST);
+    if (skeleton === null) throw new Error("expected a skeleton");
+
+    expect(JSON.parse(skeleton)).toEqual({ routes: { "/posts/[slug]": { slug: "post-0" } } });
+    expect(hasPlaceholders(skeleton)).toBe(false);
+  });
+
+  it("marks what the user has to fill in when the build knows nothing", () => {
+    const skeleton = renderConfigSkeleton(["/users/[id]"], MANIFEST);
+    if (skeleton === null) throw new Error("expected a skeleton");
+
+    expect(JSON.parse(skeleton).routes["/users/[id]"].id).toBe("REPLACE-ME");
+    expect(hasPlaceholders(skeleton)).toBe(true);
+  });
+
+  it("names every segment of a multi-parameter route", () => {
+    const skeleton = renderConfigSkeleton(["/[lang]/candidate/[candidateId]"]);
+    if (skeleton === null) throw new Error("expected a skeleton");
+
+    expect(Object.keys(JSON.parse(skeleton).routes["/[lang]/candidate/[candidateId]"])).toEqual([
+      "lang",
+      "candidateId",
+    ]);
+  });
+
+  it("covers several skipped routes in one file", () => {
+    const skeleton = renderConfigSkeleton(["/posts/[slug]", "/users/[id]"], MANIFEST);
+    if (skeleton === null) throw new Error("expected a skeleton");
+
+    expect(Object.keys(JSON.parse(skeleton).routes)).toHaveLength(2);
+  });
+
+  it("returns nothing when no route needs configuring", () => {
+    expect(renderConfigSkeleton(["/about"], MANIFEST)).toBeNull();
+    expect(renderConfigSkeleton([])).toBeNull();
+  });
+
+  it("is valid JSON the user can paste unchanged", () => {
+    const skeleton = renderConfigSkeleton(["/posts/[slug]"], MANIFEST);
+    expect(() => JSON.parse(skeleton ?? "")).not.toThrow();
+  });
+});

--- a/src/route-guidance.ts
+++ b/src/route-guidance.ts
@@ -1,0 +1,81 @@
+import { dynamicSegmentsOf } from "./route-config.js";
+import type { PrerenderManifest } from "./manifests.js";
+
+/** What to write when nothing better is known: obviously a placeholder. */
+const PLACEHOLDER = "REPLACE-ME";
+
+/**
+ * Sample values lifted from paths the build actually prerendered.
+ *
+ * A skeleton full of placeholders still leaves the user guessing what a valid
+ * value looks like. The build already knows: `prerender-manifest.json` lists
+ * concrete paths, each pointing back at its template through `srcRoute`, so a
+ * template like `/posts/[slug]` can be filled with a real `post-0` that will
+ * resolve on the first try.
+ */
+export function sampleValuesFromManifest(
+  manifest: PrerenderManifest | undefined,
+  routeTemplate: string
+): Record<string, string> | null {
+  const routes = manifest?.routes;
+  if (routes === undefined) {
+    return null;
+  }
+  const concrete = Object.entries(routes).find(([, entry]) => entry.srcRoute === routeTemplate)?.[0];
+  if (concrete === undefined) {
+    return null;
+  }
+
+  const templateSegments = routeTemplate.split("/");
+  const concreteSegments = concrete.split("/");
+  const values: Record<string, string> = {};
+  for (const [index, segment] of templateSegments.entries()) {
+    const dynamic = dynamicSegmentsOf(segment);
+    const parameter = dynamic[0];
+    if (parameter === undefined) {
+      continue;
+    }
+    // A catch-all swallows every remaining segment, so its value is the rest
+    // of the concrete path rather than one segment of it.
+    const value = parameter.catchAll
+      ? concreteSegments.slice(index).join("/")
+      : concreteSegments[index];
+    if (value === undefined || value === "") {
+      return null;
+    }
+    values[parameter.name] = value;
+  }
+  return Object.keys(values).length === 0 ? null : values;
+}
+
+/**
+ * The `next-leak.config.json` that would measure the routes a run had to skip.
+ *
+ * Printed rather than merely referenced: telling someone a config file exists
+ * and leaving them to work out its shape is the difference between a run they
+ * can fix in ten seconds and one they abandon.
+ */
+export function renderConfigSkeleton(
+  routeTemplates: readonly string[],
+  manifest: PrerenderManifest | undefined = undefined
+): string | null {
+  const routes: Record<string, Record<string, string>> = {};
+  for (const template of routeTemplates) {
+    const segments = dynamicSegmentsOf(template);
+    if (segments.length === 0) {
+      continue;
+    }
+    const sampled = sampleValuesFromManifest(manifest, template);
+    const values: Record<string, string> = {};
+    for (const segment of segments) {
+      values[segment.name] = sampled?.[segment.name] ?? PLACEHOLDER;
+    }
+    routes[template] = values;
+  }
+  return Object.keys(routes).length === 0 ? null : JSON.stringify({ routes }, null, 2);
+}
+
+/** Whether a rendered skeleton still needs the user to fill anything in. */
+export function hasPlaceholders(skeleton: string): boolean {
+  return skeleton.includes(PLACEHOLDER);
+}

--- a/src/run-report.fixture.ts
+++ b/src/run-report.fixture.ts
@@ -22,6 +22,20 @@ const cleanPhases = () => ({
       polls: 40,
     },
   ],
+  requestsPerCycle: 5000,
+  // Flat before collection as well as after it: no unreclaimed note.
+  unreclaimedSamples: [40.1, 40.4, 40.2, 40.3].map((mb) => ({
+    gcExposed: true,
+    heapUsed: mb * MB,
+    rss: 190 * MB,
+    external: 2 * MB,
+    arrayBuffers: 1 * MB,
+  })),
+  unreclaimedTrend: {
+    verdict: "stable" as const,
+    growthPerCycle: 0.05 * MB,
+    deltas: [-0.2 * MB, 0.1 * MB],
+  },
 });
 
 export function makeRunReport(): RunReport {

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -55,6 +55,8 @@ function ritualResult(route: string, samples: number[]): RitualResult {
       external: 0,
       arrayBuffers: 0,
     })),
+    unreclaimedSamples: [],
+    unreclaimedTrend: { verdict: "inconclusive" as const, growthPerCycle: 0, deltas: [] },
     baselineSnapshot: `/snap/${route}/baseline.heapsnapshot`,
     afterSnapshot: `/snap/${route}/after.heapsnapshot`,
     trend: {

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -1151,3 +1151,37 @@ describe("routeSlug", () => {
     expect(routeSlug("/ñ")).toBe(routeSlug("/ñ"));
   });
 });
+
+// The diff names the retaining object; the verdict does not depend on it.
+// Measured 2026-08-18 on the vercel/next.js#97424 reproduction: a 1.7 GB
+// snapshot cannot be read into a single string, node:fs threw, and a finished
+// measurement went down with the whole run.
+describe("a failed snapshot diff does not lose the measurement", () => {
+  it("keeps the verdict and says the diff is unavailable", async () => {
+    const events: string[] = [];
+    const appDir = await makeAppDir({ "/leaky/page": "app/leaky/page.js" });
+    const messages: string[] = [];
+    const report = await runMeasurement(
+      {
+        appDir,
+        bootstrapPath: "/fake/bootstrap.js",
+        onProgress: (message) => messages.push(message),
+      },
+      {
+        ...makeDeps(events),
+        diff: async () => {
+          throw new Error("heap snapshot is 1740 MB, past the 512 MB a single string can hold");
+        },
+      }
+    );
+
+    const route = report.routes.find((entry) => entry.route === "/leaky");
+    if (route?.status !== "measured") {
+      throw new Error("the measurement must survive a failed diff");
+    }
+    expect(route.trend.verdict).toBe("leak");
+    expect(route.diff).toBeNull();
+    expect(messages.some((message) => message.includes("snapshot diff unavailable"))).toBe(true);
+    expect(messages.some((message) => message.includes("1740 MB"))).toBe(true);
+  });
+});

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -426,6 +426,7 @@ async function measureRoute(
     minGrowthPerCycle: result.minGrowthPerCycle,
     memorySamples: result.memorySamples,
     maxOldSpaceMb: options.maxOldSpaceMb ?? DEFAULT_MAX_OLD_SPACE_MB,
+    warmupRequests: options.warmupRequests ?? RITUAL_DEFAULTS.warmupRequests,
     ...(routeConfig.abandonAfterMs !== undefined && {
       abandonAfterMs: routeConfig.abandonAfterMs,
     }),

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -27,11 +27,19 @@ import {
 } from "./ritual.js";
 import { matchSignatures, readNextVersion, type MatchedSignature } from "./signatures.js";
 import { validateTarget, type ValidatedTarget } from "./target.js";
+import { planRevalidation, revalidateSecondsFor } from "./isr.js";
 import { minGrowthFor, type TrendResult } from "./trend.js";
 
 export type RouteReport =
   | { route: string; status: "skipped"; reason: string }
   | { route: string; status: "failed"; reason: string }
+  /**
+   * The route was reachable, but the load could not have exercised the code
+   * path it represents — so no verdict is emitted. Measuring an ISR route
+   * without driving revalidation reports a flat curve about the static cache,
+   * which reads as health and is not.
+   */
+  | { route: string; status: "not-exercised"; reason: string }
   | {
       route: string;
       status: "measured";
@@ -61,6 +69,13 @@ export type RouteReport =
       unreclaimedTrend: TrendResult;
       /** Requests each cycle served — what the growth rates normalize by. */
       requestsPerCycle: number;
+      /**
+       * Seconds of the ISR revalidation period this route was driven through,
+       * when it has one. Absent on routes not served from the ISR cache.
+       * Recorded because a curve measured against a cache and one measured
+       * against a re-render are different experiments.
+       */
+      revalidatedEverySeconds?: number;
       /** RSS growth per 1000 requests, computed like the heap figure. */
       rssPer1000Requests: number;
       /** Wall-clock per phase — explains where a long run spent its time. */
@@ -349,6 +364,14 @@ async function measureRoute(
   pass: { cycles: number; dirSuffix: string } | undefined = undefined
 ): Promise<RouteReport> {
   const { deps, options, target, workDir, routeConfig, registry, nextVersion, progress } = context;
+  // An ISR route serves its cache unless the request carries the build's own
+  // revalidation header; without it the load measures the static cache and
+  // nothing else.
+  const plan = planRevalidation(target.prerender, route.path, routeConfig.headers);
+  const revalidateSeconds = revalidateSecondsFor(target.prerender, route.path);
+  const driven = plan.kind === "drive" ? plan.headers : {};
+  const merged = { ...driven, ...(routeConfig.headers ?? {}) };
+  const headers = Object.keys(merged).length === 0 ? undefined : merged;
   const result = await deps.ritual({
     serverPath: target.standaloneServer,
     route: requestPath,
@@ -366,7 +389,7 @@ async function measureRoute(
       : options.cycles !== undefined && { cycles: options.cycles }),
     ...(options.idleMs !== undefined && { idleMs: options.idleMs }),
     ...(options.maxOldSpaceMb !== undefined && { maxOldSpaceMb: options.maxOldSpaceMb }),
-    ...(routeConfig.headers !== undefined && { headers: routeConfig.headers }),
+    ...(headers !== undefined && { headers }),
     ...(routeConfig.abandonAfterMs !== undefined && {
       abandonAfterMs: routeConfig.abandonAfterMs,
     }),
@@ -407,6 +430,7 @@ async function measureRoute(
     samples: result.samples,
     memorySamples: result.memorySamples,
     peaks: result.peaks,
+    ...(revalidateSeconds !== null && { revalidatedEverySeconds: revalidateSeconds }),
     unreclaimedSamples: result.unreclaimedSamples,
     unreclaimedTrend: result.unreclaimedTrend,
     requestsPerCycle: result.requestsPerCycle,
@@ -456,6 +480,11 @@ async function routeReportFor(
   if (reason !== null || requestPath === null) {
     progress(`skipping ${label}: ${reason ?? "needs sample params"}`);
     return { route: route.path, status: "skipped", reason: reason ?? "needs sample params" };
+  }
+  const plan = planRevalidation(context.target.prerender, route.path, routeConfig.headers);
+  if (plan.kind === "cannot-drive") {
+    progress(`not measuring ${label}: ${plan.reason}`);
+    return { route: route.path, status: "not-exercised", reason: plan.reason };
   }
   try {
     const asPath = requestPath === route.path ? "" : ` as ${requestPath}`;

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -14,7 +14,12 @@ import type { HeapSample } from "./control-server.js";
 import { captureEnvironment, type MeasurementEnvironment } from "./environment.js";
 import { diffSnapshotFiles, type HeapDiff } from "./heap-diff.js";
 import { DEFAULT_MAX_OLD_SPACE_MB } from "./launcher.js";
-import { discoverPagesRoutes, discoverRoutes, type DiscoveredRoute } from "./manifests.js";
+import {
+  discoverPagesRoutes,
+  discoverRoutes,
+  type DiscoveredRoute,
+  type PrerenderManifest,
+} from "./manifests.js";
 import { extractModuleRegistry } from "./module-registry.js";
 import { loadRouteConfig, resolveRoutePath, type RouteConfig } from "./route-config.js";
 import {
@@ -132,6 +137,8 @@ export type RunReport = {
   appDir: string;
   startedAt: string;
   workDir: string;
+  /** Carried so the report can suggest sample params the build already knows. */
+  prerender?: PrerenderManifest;
   environment: MeasurementEnvironment;
   parameters: RunParameters;
   routes: RouteReport[];
@@ -637,6 +644,7 @@ export async function runMeasurement(
     appDir: target.appDir,
     startedAt: startedAt.toISOString(),
     workDir,
+    ...(target.prerender !== undefined && { prerender: target.prerender }),
     environment: captureEnvironment(nextVersion),
     parameters,
     routes: reports,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -21,7 +21,12 @@ import {
   type PrerenderManifest,
 } from "./manifests.js";
 import { extractModuleRegistry } from "./module-registry.js";
-import { loadRouteConfig, resolveRoutePath, type RouteConfig } from "./route-config.js";
+import {
+  boundedMarkerOf,
+  loadRouteConfig,
+  resolveRoutePath,
+  type RouteConfig,
+} from "./route-config.js";
 import {
   RITUAL_DEFAULTS,
   runRitual,
@@ -74,6 +79,12 @@ export type RouteReport =
       unreclaimedTrend: TrendResult;
       /** Requests each cycle served — what the growth rates normalize by. */
       requestsPerCycle: number;
+      /**
+       * Distinct keys the load cycled through, when the route asked for a
+       * bounded set. A verdict about a cache depends on how many keys it saw,
+       * so the number belongs on the record with the rest of the regime.
+       */
+      keyCardinality?: number;
       /**
        * Seconds of the ISR revalidation period this route was driven through,
        * when it has one. Absent on routes not served from the ISR cache.
@@ -376,6 +387,7 @@ async function measureRoute(
   // nothing else.
   const plan = planRevalidation(target.prerender, route.path, routeConfig.headers);
   const revalidateSeconds = revalidateSecondsFor(target.prerender, route.path);
+  const bounded = boundedMarkerOf(requestPath);
   const driven = plan.kind === "drive" ? plan.headers : {};
   const merged = { ...driven, ...(routeConfig.headers ?? {}) };
   const headers = Object.keys(merged).length === 0 ? undefined : merged;
@@ -438,6 +450,7 @@ async function measureRoute(
     memorySamples: result.memorySamples,
     peaks: result.peaks,
     ...(revalidateSeconds !== null && { revalidatedEverySeconds: revalidateSeconds }),
+    ...(bounded !== null && { keyCardinality: bounded.bound }),
     unreclaimedSamples: result.unreclaimedSamples,
     unreclaimedTrend: result.unreclaimedTrend,
     requestsPerCycle: result.requestsPerCycle,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -439,7 +439,18 @@ async function measureRoute(
   let diff: HeapDiff | null = null;
   if (verdict !== "stable" || options.diffAll === true) {
     progress(`diffing snapshots for ${route.path}`);
-    diff = await deps.diff(result.baselineSnapshot, result.afterSnapshot);
+    try {
+      diff = await deps.diff(result.baselineSnapshot, result.afterSnapshot);
+    } catch (cause) {
+      // The diff names the retaining object; the verdict does not depend on
+      // it. Losing a finished measurement because the extra step failed is
+      // the worse outcome by far — measured on the #97424 reproduction, where
+      // a 1.7 GB snapshot took the whole run down with it.
+      progress(
+        `snapshot diff unavailable for ${route.path}: ` +
+          `${cause instanceof Error ? cause.message : String(cause)}`
+      );
+    }
   }
 
   return {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -50,6 +50,17 @@ export type RouteReport =
        * here is post-GC; this is the one a container limit is judged against.
        */
       peaks: PeakSample[];
+      /**
+       * One reading per cycle taken before any forced collection, and the
+       * trend over them. What a production process holds between full GCs is
+       * not what this tool's verdict measures — see `unreclaimed-retention`.
+       * Empty when a reading was lost: a hole would make every later delta
+       * span two cycles.
+       */
+      unreclaimedSamples: HeapSample[];
+      unreclaimedTrend: TrendResult;
+      /** Requests each cycle served — what the growth rates normalize by. */
+      requestsPerCycle: number;
       /** RSS growth per 1000 requests, computed like the heap figure. */
       rssPer1000Requests: number;
       /** Wall-clock per phase — explains where a long run spent its time. */
@@ -396,6 +407,9 @@ async function measureRoute(
     samples: result.samples,
     memorySamples: result.memorySamples,
     peaks: result.peaks,
+    unreclaimedSamples: result.unreclaimedSamples,
+    unreclaimedTrend: result.unreclaimedTrend,
+    requestsPerCycle: result.requestsPerCycle,
     timings: result.timings,
     loadOutcomes: result.loadOutcomes,
     settleOutcomes: result.settleOutcomes,

--- a/src/target.ts
+++ b/src/target.ts
@@ -3,9 +3,11 @@ import path from "node:path";
 import {
   appPathsManifestSchema,
   pagesManifestSchema,
+  prerenderManifestSchema,
   routesManifestSchema,
   type AppPathsManifest,
   type PagesManifest,
+  type PrerenderManifest,
   type RoutesManifest,
 } from "./manifests.js";
 
@@ -29,6 +31,11 @@ export type ValidatedTarget = {
   pages: PagesManifest;
   /** Absent on builds that do not emit it; nothing downstream reads it. */
   routes: RoutesManifest | undefined;
+  /**
+   * Absent on builds with nothing prerendered. Carries which routes revalidate
+   * and the `previewModeId` needed to make them re-render under load.
+   */
+  prerender: PrerenderManifest | undefined;
 };
 
 async function exists(file: string): Promise<boolean> {
@@ -119,5 +126,19 @@ export async function validateTarget(appDir: string): Promise<ValidatedTarget> {
     ? await readManifest(routesFile, (raw) => routesManifestSchema.parse(raw))
     : undefined;
 
-  return { appDir: path.resolve(appDir), standaloneServer, appPaths, pages, routes };
+  // Absent on an app with nothing prerendered, which is not an error: it just
+  // means no route needs driving through revalidation.
+  const prerenderFile = path.join(nextDir, "prerender-manifest.json");
+  const prerender = (await exists(prerenderFile))
+    ? await readManifest(prerenderFile, (raw) => prerenderManifestSchema.parse(raw))
+    : undefined;
+
+  return {
+    appDir: path.resolve(appDir),
+    standaloneServer,
+    appPaths,
+    pages,
+    routes,
+    prerender,
+  };
 }

--- a/src/trend.test.ts
+++ b/src/trend.test.ts
@@ -210,10 +210,19 @@ describe("stepwise growth", () => {
     expect(result.growthPerCycle).toBeGreaterThan(10 * MB);
   });
 
-  it("still calls an oscillating route stable, however small the dip", () => {
-    // A healthy route gives back a real share of what it took. Measured
-    // healthy routes drew down 22–33% of net growth; this is 20%.
+  it("leaves an oscillating route undecided once the dip is dwarfed by the climb", () => {
+    // A healthy route gives back a real share of what it took, and this one
+    // draws down 20% of net growth — but it also averages 6 MB per cycle,
+    // 24x the gate. Give-back only acquits while the growth around it is
+    // small; every healthy route ever measured here averaged under 2x.
     const samples = [10 * MB, 20 * MB, 30 * MB, 28 * MB, 38 * MB];
+    expect(classifyTrend(samples).verdict).toBe("inconclusive");
+  });
+
+  it("still calls a modest oscillating route stable, however small the dip", () => {
+    // Same shape, scaled to the magnitude of a real healthy route: 0.3 MB per
+    // cycle against the 256 KiB gate.
+    const samples = [10 * MB, 20 * MB, 20.5 * MB, 20.4 * MB, 20.9 * MB];
     expect(classifyTrend(samples).verdict).toBe("stable");
   });
 
@@ -240,6 +249,68 @@ describe("stepwise growth", () => {
     const result = classifyMemoryTrend(flat, stepwise);
 
     expect(result.verdict).toBe("leak");
+    expect(result.source).toBe("external");
+  });
+});
+
+// An app that dies of OOM must not come back `stable`. The acquittal for a
+// flat or negative cycle is bounded by how much the series grew around it.
+describe("withdrawn acquittal on large oscillating series", () => {
+  // Real measurement, 2026-08-17: the repro of vercel/next.js#97424 measured
+  // at 300 requests per cycle. The process was killed at a 512 MB heap cap and
+  // again at 1024 MB, and peaked at 4577 MB RSS; this run reported `stable`.
+  const ISSUE_97424 = [861.7, 129.4, 253.0, 179.1, 107.1, 184.1, 235.5].map((mb) => mb * MB);
+  const GATE_AT_300_REQUESTS = minGrowthFor(300);
+
+  it("leaves the #97424 series undecided instead of calling it stable", () => {
+    const result = classifyTrend(ISSUE_97424, { minGrowthPerCycle: GATE_AT_300_REQUESTS });
+    expect(result.verdict).toBe("inconclusive");
+  });
+
+  it("does not turn the #97424 series into an accusation", () => {
+    // A magnitude is not a shape: the evidence defeats the acquittal without
+    // supporting a leak verdict.
+    const result = classifyTrend(ISSUE_97424, { minGrowthPerCycle: GATE_AT_300_REQUESTS });
+    expect(result.verdict).not.toBe("leak");
+  });
+
+  it("keeps the measured healthy routes on the acquitted side of the line", () => {
+    // The phase-0 fixtures that do reach this branch: both dip, and both
+    // average well under 2x the gate. The 8x line has to clear them by a wide
+    // margin or the July false positives come back through another door.
+    const macos = [29.4 * MB, 31.5 * MB, 32.3 * MB, 32.1 * MB];
+    const linux = [28.0 * MB, 32.3 * MB, 32.1 * MB, 33.2 * MB];
+
+    expect(classifyTrend(macos).verdict).toBe("stable");
+    expect(classifyTrend(linux).verdict).toBe("stable");
+  });
+
+  it("withdraws the acquittal from the same shape scaled up tenfold", () => {
+    // Identical curve shape to the healthy Linux fixture, ten times the
+    // magnitude. Shape alone no longer decides it.
+    const samples = [280 * MB, 323 * MB, 321 * MB, 332 * MB];
+    expect(classifyTrend(samples).verdict).toBe("inconclusive");
+  });
+
+  it("acquits a large oscillation that ends where it started", () => {
+    // Net growth of zero over the analyzed window is a transient, however big
+    // the swings: the series has to be going somewhere.
+    const samples = [10 * MB, 40 * MB, 90 * MB, 30 * MB, 40 * MB];
+    expect(classifyTrend(samples).verdict).toBe("stable");
+  });
+
+  it("acquits a large oscillation that ends below where it started", () => {
+    const samples = [10 * MB, 40 * MB, 90 * MB, 30 * MB, 35 * MB];
+    expect(classifyTrend(samples).verdict).toBe("stable");
+  });
+
+  it("withdraws the acquittal on external memory too", () => {
+    const flatHeap = [10 * MB, 11 * MB, 11 * MB, 11 * MB, 11 * MB];
+    const result = classifyMemoryTrend(flatHeap, ISSUE_97424, {
+      minGrowthPerCycle: GATE_AT_300_REQUESTS,
+    });
+
+    expect(result.verdict).toBe("inconclusive");
     expect(result.source).toBe("external");
   });
 });

--- a/src/trend.ts
+++ b/src/trend.ts
@@ -66,6 +66,21 @@ export function minGrowthFor(requestsPerCycle: number): number {
 const STEPWISE_MIN_GROWING_CYCLES = 2;
 /** Share of net growth a series may give back and still count as monotonic. */
 const STEPWISE_MAX_DRAWDOWN_RATIO = 0.1;
+/**
+ * How far above the gate a series' mean growth may sit and still be acquitted
+ * by a flat or negative cycle.
+ *
+ * A give-back only means a plateau when the growth around it is small. On the
+ * repro of vercel/next.js#97424 — an app that died of OOM at a 1 GB heap cap
+ * and peaked at 4577 MB RSS — the deltas were
+ * [+129.6, -77.4, -75.5, +80.8, +53.9] MB against a 0.25 MB gate: mean growth
+ * 85x the gate, and the two negatives were enough to call it `stable`.
+ *
+ * Every healthy route ever measured here sits below 2x: the phase-0 fixtures
+ * below are 1.2x and 1.8x, and the worst of the July validation set was 1.96x.
+ * 8x leaves four times that headroom and still catches #97424 tenfold over.
+ */
+const ACQUITTAL_MAX_GROWTH_MULTIPLE = 8;
 
 /**
  * Largest give-back from a running peak, over the post-warm-up window.
@@ -114,6 +129,24 @@ function isStepwiseGrowth(
 }
 
 /**
+ * Whether a series is growing too much to be excused by a flat cycle.
+ *
+ * Both terms are load-bearing. The mean alone would flag a route that spikes
+ * once and comes back down — a transient, which this tool exists to tell apart
+ * from a leak; net growth alone would flag any route that ends a hair above
+ * where it started. Together they describe a series that is both large and
+ * going somewhere, which is not something six samples can acquit.
+ */
+function isTooLargeToAcquit(
+  deltas: readonly number[],
+  mean: number,
+  minGrowth: number
+): boolean {
+  const netGrowth = deltas.reduce((sum, delta) => sum + delta, 0);
+  return mean >= minGrowth * ACQUITTAL_MAX_GROWTH_MULTIPLE && netGrowth > 0;
+}
+
+/**
  * Classifies a series of post-GC retained-heap samples — baseline first, then
  * one sample per load cycle — as leaking or stable.
  *
@@ -146,12 +179,16 @@ export function classifyTrend(samples: readonly number[], options: TrendOptions 
 
   // Post-GC samples of a real leak grow every cycle; a healthy route
   // oscillates around its plateau, so at least one delta goes flat or
-  // negative (observed on every healthy phase-0 run). Exactly three outcomes:
+  // negative (observed on every healthy phase-0 run). Four outcomes:
   //   leak         — every cycle grows by at least the threshold
-  //   stable       — some cycle went flat/down, or the mean is below the
-  //                  threshold (small consistent drift is measurement noise)
+  //   stable       — some cycle went flat/down while the growth around it was
+  //                  small, or the mean is below the threshold (small
+  //                  consistent drift is measurement noise)
   //   inconclusive — never flat, no cycle reaches the threshold alone, yet
-  //                  the mean does: too close to call, measure more cycles
+  //                  the mean does: too close to call, measure more cycles.
+  //                  Also where a large oscillating series lands: the
+  //                  acquittal is withdrawn, but a magnitude is not a shape
+  //                  and will not carry an accusation.
   if (allGrow) {
     return { verdict: "leak", growthPerCycle: mean, deltas, source: "heap" };
   }
@@ -159,6 +196,9 @@ export function classifyTrend(samples: readonly number[], options: TrendOptions 
     return { verdict: "leak", growthPerCycle: mean, deltas, source: "heap" };
   }
   if (anyFlatOrDown || mean < minGrowth) {
+    if (isTooLargeToAcquit(deltas, mean, minGrowth)) {
+      return { verdict: "inconclusive", growthPerCycle: mean, deltas, source: "heap" };
+    }
     return { verdict: "stable", growthPerCycle: mean, deltas, source: "heap" };
   }
   return { verdict: "inconclusive", growthPerCycle: mean, deltas, source: "heap" };

--- a/src/unreclaimed-retention.test.ts
+++ b/src/unreclaimed-retention.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import {
+  assessUnreclaimedRetention,
+  describeUnreclaimedRetention,
+} from "./unreclaimed-retention.js";
+import type { TrendResult } from "./trend.js";
+
+const MB = 1024 * 1024;
+
+const growing = (source: "heap" | "external" = "heap"): TrendResult => ({
+  verdict: "leak",
+  growthPerCycle: 10 * MB,
+  deltas: [10 * MB, 10 * MB],
+  source,
+});
+
+const flat: TrendResult = {
+  verdict: "stable",
+  growthPerCycle: 0.05 * MB,
+  deltas: [-0.1 * MB, 0.2 * MB],
+  source: "heap",
+};
+
+describe("assessUnreclaimedRetention", () => {
+  it("reports memory held before collection that a GC takes back", () => {
+    // The vercel/next.js#96533 shape: climbs before collection, flat after it.
+    const retention = assessUnreclaimedRetention({
+      unreclaimedTrend: growing(),
+      verdict: "stable",
+      requestsPerCycle: 2000,
+    });
+
+    expect(retention).not.toBeNull();
+    expect(retention?.class).toBe("heap");
+    expect(retention?.growthPer1000Requests).toBe(5 * MB);
+  });
+
+  it("names external memory when that is the class that grew", () => {
+    const retention = assessUnreclaimedRetention({
+      unreclaimedTrend: growing("external"),
+      verdict: "stable",
+      requestsPerCycle: 2000,
+    });
+
+    expect(retention?.class).toBe("external");
+  });
+
+  it("stays quiet when the route already leaks", () => {
+    // The retention is the headline there; a weaker restatement is noise.
+    expect(
+      assessUnreclaimedRetention({
+        unreclaimedTrend: growing(),
+        verdict: "leak",
+        requestsPerCycle: 2000,
+      })
+    ).toBeNull();
+  });
+
+  it("stays quiet when nothing accumulates before collection", () => {
+    expect(
+      assessUnreclaimedRetention({
+        unreclaimedTrend: flat,
+        verdict: "stable",
+        requestsPerCycle: 2000,
+      })
+    ).toBeNull();
+  });
+
+  it("stays quiet when the pre-collection series is merely undecided", () => {
+    // That series is noisy by nature — nothing has been collected — so only a
+    // series that grows every cycle is worth interrupting a run for.
+    expect(
+      assessUnreclaimedRetention({
+        unreclaimedTrend: { ...growing(), verdict: "inconclusive" },
+        verdict: "stable",
+        requestsPerCycle: 2000,
+      })
+    ).toBeNull();
+  });
+
+  it("stays quiet when the series was dropped and carries no growth", () => {
+    expect(
+      assessUnreclaimedRetention({
+        unreclaimedTrend: { verdict: "leak", growthPerCycle: 0, deltas: [] },
+        verdict: "stable",
+        requestsPerCycle: 2000,
+      })
+    ).toBeNull();
+  });
+
+  it("does not divide by a cycle that served no requests", () => {
+    expect(
+      assessUnreclaimedRetention({
+        unreclaimedTrend: growing(),
+        verdict: "stable",
+        requestsPerCycle: 0,
+      })
+    ).toBeNull();
+  });
+
+  it("reports the same finding for an inconclusive verdict", () => {
+    // Only `leak` silences it: an undecided route can still be sitting on
+    // memory nothing has collected.
+    expect(
+      assessUnreclaimedRetention({
+        unreclaimedTrend: growing(),
+        verdict: "inconclusive",
+        requestsPerCycle: 2000,
+      })
+    ).not.toBeNull();
+  });
+});
+
+describe("describeUnreclaimedRetention", () => {
+  it("states the rate, the class and its own limits", () => {
+    const line = describeUnreclaimedRetention({
+      class: "external",
+      growthPerCycle: 10 * MB,
+      growthPer1000Requests: 5 * MB,
+    });
+
+    expect(line).toContain("external memory");
+    expect(line).toContain("5.00 MB/1000 req");
+    // Never contradicts the verdict beside it, and never overstates itself.
+    expect(line).toContain("a forced GC reclaims this");
+    expect(line).toContain("seconds after load");
+    expect(line).toContain("while staying flat after it");
+  });
+
+  it("names the heap when the heap is what grew", () => {
+    const line = describeUnreclaimedRetention({
+      class: "heap",
+      growthPerCycle: 4 * MB,
+      growthPer1000Requests: 2 * MB,
+    });
+
+    expect(line).toContain("heap grew 2.00 MB/1000 req");
+    expect(line).not.toContain("external memory");
+  });
+});

--- a/src/unreclaimed-retention.test.ts
+++ b/src/unreclaimed-retention.test.ts
@@ -55,12 +55,14 @@ describe("assessUnreclaimedRetention", () => {
 
     expect(retention).not.toBeNull();
     expect(retention?.class).toBe("arrayBuffers");
-    expect((retention?.medianGapBytes ?? 0) / MB).toBeCloseTo(3.96, 1);
+    // The largest gap observed, not the typical one: a cycle that held 5.40 MB
+    // proves the process can, while a cycle at zero only proves it had just
+    // been collected.
+    expect((retention?.largestGapBytes ?? 0) / MB).toBeCloseTo(5.4, 1);
   });
 
   it("names the class where holding is most out of proportion, not the biggest", () => {
-    // Measured ratios: heap 0.68x, external 0.99x, arrayBuffers 3.96x. The
-    // heap gap is far larger in megabytes (18.8 vs 3.96), but arrayBuffers is
+    // The heap gap is far larger in megabytes (24.8 vs 5.40), but arrayBuffers is
     // where the process holds many times what it keeps — that names the
     // mechanism the issue describes.
     const retention = assessUnreclaimedRetention({
@@ -187,7 +189,7 @@ describe("assessUnreclaimedRetention", () => {
     });
 
     // Only two cycles pair up; the rule still runs on what it has.
-    expect(retention === null || retention.medianGapBytes > 0).toBe(true);
+    expect(retention === null || retention.largestGapBytes > 0).toBe(true);
   });
 });
 
@@ -195,7 +197,7 @@ describe("describeUnreclaimedRetention", () => {
   it("states the gap, the class and its own limits", () => {
     const line = describeUnreclaimedRetention({
       class: "arrayBuffers",
-      medianGapBytes: 3.96 * MB,
+      largestGapBytes: 3.96 * MB,
       retainedBytes: 0.32 * MB,
       ratio: 3.96,
     });
@@ -209,11 +211,40 @@ describe("describeUnreclaimedRetention", () => {
   it("labels external memory readably", () => {
     const line = describeUnreclaimedRetention({
       class: "external",
-      medianGapBytes: 5 * MB,
+      largestGapBytes: 5 * MB,
       retainedBytes: 2 * MB,
       ratio: 2.5,
     });
 
     expect(line).toContain("external memory");
+  });
+});
+
+// Run 3 of the real reproduction: four of six cycles collected on their own
+// just before the reading, so their gap is zero. A median reports nothing
+// about an app that demonstrably held 3.79 MB in another cycle.
+describe("a run where most cycles happened to be collected", () => {
+  const RUN_3 = {
+    unreclaimed: samples({
+      heap: [40, 40, 40, 40, 40, 40],
+      arrayBuffers: [0.32, 1.81, 0.32, 0.32, 4.11, 0.32],
+    }),
+    postGc: samples({
+      heap: [27.1, 26.3, 27.3, 27.6, 27.7, 27.8, 27.8],
+      arrayBuffers: [0.32, 0.32, 0.32, 0.32, 0.32, 0.32, 0.32],
+    }),
+  };
+
+  it("still reports what the process was seen holding", () => {
+    const retention = assessUnreclaimedRetention({
+      unreclaimedSamples: RUN_3.unreclaimed,
+      memorySamples: RUN_3.postGc,
+      verdict: "stable",
+      verdictIsWellSupported: false,
+    });
+
+    expect(retention).not.toBeNull();
+    expect(retention?.class).toBe("arrayBuffers");
+    expect((retention?.largestGapBytes ?? 0) / MB).toBeCloseTo(3.79, 1);
   });
 });

--- a/src/unreclaimed-retention.test.ts
+++ b/src/unreclaimed-retention.test.ts
@@ -248,3 +248,50 @@ describe("a run where most cycles happened to be collected", () => {
     expect((retention?.largestGapBytes ?? 0) / MB).toBeCloseTo(3.79, 1);
   });
 });
+
+// Boundaries the mutation run found unfixed: each of these is a calibrated
+// value whose exact edge nothing pinned down.
+describe("threshold boundaries", () => {
+  it("fires on a gap sitting exactly on the floor", () => {
+    // 3 MB held against 1 MB retained: a gap of exactly 2 MB. `<` lets the
+    // equal case through and `<=` would not, and the difference decides
+    // whether a route on the line is reported at all.
+    const retention = assessUnreclaimedRetention({
+      unreclaimedSamples: samples({ heap: [3, 3, 3, 3] }),
+      memorySamples: samples({ heap: [1, 1, 1, 1, 1] }),
+      verdict: "stable",
+      verdictIsWellSupported: true,
+    });
+
+    expect(retention).not.toBeNull();
+    expect((retention?.largestGapBytes ?? 0) / MB).toBeCloseTo(2, 2);
+  });
+
+  it("measures what is retained from the cycles, not from the baseline", () => {
+    // The baseline is warm-up's level, not the app's. Folding it into the
+    // denominator here would make a 20 MB gap over 10 MB retained (2.0x) read
+    // as 20 over 100 (0.2x) and silence the note.
+    const retention = assessUnreclaimedRetention({
+      unreclaimedSamples: samples({ heap: [30, 30, 30, 30] }),
+      memorySamples: samples({ heap: [100, 10, 10, 10, 10] }),
+      verdict: "stable",
+      verdictIsWellSupported: true,
+    });
+
+    expect(retention).not.toBeNull();
+    expect(retention?.retainedBytes ?? 0).toBe(10 * MB);
+    expect(retention?.ratio ?? 0).toBeCloseTo(2, 1);
+  });
+
+  it("names external memory when that is the class out of proportion", () => {
+    // arrayBuffers flat, external holding: the label has to follow the data.
+    const retention = assessUnreclaimedRetention({
+      unreclaimedSamples: samples({ heap: [10, 10, 10, 10], external: [9, 9, 9, 9] }),
+      memorySamples: samples({ heap: [9, 9, 9, 9, 9], external: [1, 1, 1, 1, 1] }),
+      verdict: "stable",
+      verdictIsWellSupported: true,
+    });
+
+    expect(retention?.class).toBe("external");
+  });
+});

--- a/src/unreclaimed-retention.test.ts
+++ b/src/unreclaimed-retention.test.ts
@@ -3,138 +3,217 @@ import {
   assessUnreclaimedRetention,
   describeUnreclaimedRetention,
 } from "./unreclaimed-retention.js";
-import type { TrendResult } from "./trend.js";
+import type { HeapSample } from "./control-server.js";
 
 const MB = 1024 * 1024;
 
-const growing = (source: "heap" | "external" = "heap"): TrendResult => ({
-  verdict: "leak",
-  growthPerCycle: 10 * MB,
-  deltas: [10 * MB, 10 * MB],
-  source,
-});
+type Series = { heap: number[]; external?: number[]; arrayBuffers?: number[] };
 
-const flat: TrendResult = {
-  verdict: "stable",
-  growthPerCycle: 0.05 * MB,
-  deltas: [-0.1 * MB, 0.2 * MB],
-  source: "heap",
+const samples = ({ heap, external, arrayBuffers }: Series): HeapSample[] =>
+  heap.map((mb, index) => ({
+    gcExposed: true,
+    heapUsed: mb * MB,
+    rss: 3 * mb * MB,
+    external: (external?.[index] ?? arrayBuffers?.[index] ?? 0) * MB,
+    arrayBuffers: (arrayBuffers?.[index] ?? 0) * MB,
+  }));
+
+// Every fixture below is a real measurement taken on 2026-08-18 and recorded in
+// the change's field-validation.md.
+
+/** vercel/next.js#96533: held between collections, flat after one. */
+const ISSUE_96533 = {
+  unreclaimed: samples({
+    heap: [46.5, 27.8, 48.0, 45.1, 39.2, 52.7],
+    external: [7.77, 5.62, 8.68, 8.09, 7.0, 9.37],
+    arrayBuffers: [4.11, 0.32, 5.03, 4.44, 3.35, 5.72],
+  }),
+  // Baseline first, then one per cycle.
+  postGc: samples({
+    heap: [27.1, 26.3, 27.3, 27.6, 27.8, 27.8, 27.9],
+    external: [3.98, 3.98, 3.98, 3.97, 3.98, 3.98, 3.97],
+    arrayBuffers: [0.32, 0.32, 0.32, 0.32, 0.32, 0.32, 0.32],
+  }),
+};
+
+/** The healthy fixture route: median gap 0.77 MB, 0.11x what it retains. */
+const HEALTHY = {
+  unreclaimed: samples({ heap: [9.0, 7.7, 7.7, 7.9, 8.4, 8.1] }),
+  postGc: samples({ heap: [7.3, 7.1, 7.1, 7.2, 7.2, 7.2, 7.3] }),
 };
 
 describe("assessUnreclaimedRetention", () => {
-  it("reports memory held before collection that a GC takes back", () => {
-    // The vercel/next.js#96533 shape: climbs before collection, flat after it.
+  it("finds the #96533 gap that the old slope rule missed entirely", () => {
+    // That pre-collection series classifies as `inconclusive` on its own — it
+    // oscillates rather than climbs. The gap is what carries the finding.
     const retention = assessUnreclaimedRetention({
-      unreclaimedTrend: growing(),
+      unreclaimedSamples: ISSUE_96533.unreclaimed,
+      memorySamples: ISSUE_96533.postGc,
       verdict: "stable",
-      requestsPerCycle: 2000,
+      verdictIsWellSupported: true,
     });
 
     expect(retention).not.toBeNull();
-    expect(retention?.class).toBe("heap");
-    expect(retention?.growthPer1000Requests).toBe(5 * MB);
+    expect(retention?.class).toBe("arrayBuffers");
+    expect((retention?.medianGapBytes ?? 0) / MB).toBeCloseTo(3.96, 1);
   });
 
-  it("names external memory when that is the class that grew", () => {
+  it("names the class where holding is most out of proportion, not the biggest", () => {
+    // Measured ratios: heap 0.68x, external 0.99x, arrayBuffers 3.96x. The
+    // heap gap is far larger in megabytes (18.8 vs 3.96), but arrayBuffers is
+    // where the process holds many times what it keeps — that names the
+    // mechanism the issue describes.
     const retention = assessUnreclaimedRetention({
-      unreclaimedTrend: growing("external"),
+      unreclaimedSamples: ISSUE_96533.unreclaimed,
+      memorySamples: ISSUE_96533.postGc,
       verdict: "stable",
-      requestsPerCycle: 2000,
+      verdictIsWellSupported: true,
     });
 
-    expect(retention?.class).toBe("external");
+    expect(retention?.class).toBe("arrayBuffers");
+    expect(retention?.ratio ?? 0).toBeGreaterThan(3);
+  });
+
+  it("stays quiet on a healthy route", () => {
+    expect(
+      assessUnreclaimedRetention({
+        unreclaimedSamples: HEALTHY.unreclaimed,
+        memorySamples: HEALTHY.postGc,
+        verdict: "stable",
+        verdictIsWellSupported: true,
+      })
+    ).toBeNull();
+  });
+
+  it("is not fooled by one cycle that collected on its own", () => {
+    // Cycle 2 of the real #96533 run fell back to the post-GC level because V8
+    // collected just before the reading. A mean would let that drag the
+    // finding down; the median holds.
+    const retention = assessUnreclaimedRetention({
+      unreclaimedSamples: ISSUE_96533.unreclaimed,
+      memorySamples: ISSUE_96533.postGc,
+      verdict: "stable",
+      verdictIsWellSupported: true,
+    });
+
+    expect(retention).not.toBeNull();
   });
 
   it("stays quiet when the route already leaks", () => {
-    // The retention is the headline there; a weaker restatement is noise.
     expect(
       assessUnreclaimedRetention({
-        unreclaimedTrend: growing(),
+        unreclaimedSamples: ISSUE_96533.unreclaimed,
+        memorySamples: ISSUE_96533.postGc,
         verdict: "leak",
-        requestsPerCycle: 2000,
+        verdictIsWellSupported: true,
       })
     ).toBeNull();
   });
 
-  it("stays quiet when nothing accumulates before collection", () => {
-    expect(
-      assessUnreclaimedRetention({
-        unreclaimedTrend: flat,
-        verdict: "stable",
-        requestsPerCycle: 2000,
-      })
-    ).toBeNull();
+  it("is not silenced by a marginal leak carrying low-confidence warnings", () => {
+    // Measured on #96533 2026-08-18: the post-GC verdict came back `leak` at
+    // +0.15 MB/1000 req with two low-confidence warnings — noise grazing the
+    // threshold — while the gap was 3.96 MB of arrayBuffers at 4x what the
+    // route retains. Silencing on any `leak` let the weaker finding hide the
+    // stronger one, and the note never appeared on the app it exists for.
+    const retention = assessUnreclaimedRetention({
+      unreclaimedSamples: ISSUE_96533.unreclaimed,
+      memorySamples: ISSUE_96533.postGc,
+      verdict: "leak",
+      verdictIsWellSupported: false,
+    });
+
+    expect(retention).not.toBeNull();
+    expect(retention?.class).toBe("arrayBuffers");
   });
 
-  it("stays quiet when the pre-collection series is merely undecided", () => {
-    // That series is noisy by nature — nothing has been collected — so only a
-    // series that grows every cycle is worth interrupting a run for.
+  it("still reports on an undecided route", () => {
     expect(
       assessUnreclaimedRetention({
-        unreclaimedTrend: { ...growing(), verdict: "inconclusive" },
-        verdict: "stable",
-        requestsPerCycle: 2000,
-      })
-    ).toBeNull();
-  });
-
-  it("stays quiet when the series was dropped and carries no growth", () => {
-    expect(
-      assessUnreclaimedRetention({
-        unreclaimedTrend: { verdict: "leak", growthPerCycle: 0, deltas: [] },
-        verdict: "stable",
-        requestsPerCycle: 2000,
-      })
-    ).toBeNull();
-  });
-
-  it("does not divide by a cycle that served no requests", () => {
-    expect(
-      assessUnreclaimedRetention({
-        unreclaimedTrend: growing(),
-        verdict: "stable",
-        requestsPerCycle: 0,
-      })
-    ).toBeNull();
-  });
-
-  it("reports the same finding for an inconclusive verdict", () => {
-    // Only `leak` silences it: an undecided route can still be sitting on
-    // memory nothing has collected.
-    expect(
-      assessUnreclaimedRetention({
-        unreclaimedTrend: growing(),
+        unreclaimedSamples: ISSUE_96533.unreclaimed,
+        memorySamples: ISSUE_96533.postGc,
         verdict: "inconclusive",
-        requestsPerCycle: 2000,
+        verdictIsWellSupported: true,
       })
     ).not.toBeNull();
+  });
+
+  it("stays quiet when a large gap is small next to what is retained", () => {
+    // The deliberately leaky fixture: 5.13 MB held over 24.4 MB retained, a
+    // 0.21x ratio. Its memory really is retained after a GC — that is a leak,
+    // not this. Clears the absolute floor, fails the ratio.
+    const retention = assessUnreclaimedRetention({
+      unreclaimedSamples: samples({ heap: [30.3, 45.2, 60.0, 76.0, 91.0, 105.9] }),
+      memorySamples: samples({ heap: [8.8, 24.4, 40.1, 54.9, 70.5, 86.3, 102.0] }),
+      verdict: "stable",
+      verdictIsWellSupported: true,
+    });
+
+    expect(retention).toBeNull();
+  });
+
+  it("stays quiet when there is no pre-collection series", () => {
+    expect(
+      assessUnreclaimedRetention({
+        unreclaimedSamples: [],
+        memorySamples: HEALTHY.postGc,
+        verdict: "stable",
+        verdictIsWellSupported: true,
+      })
+    ).toBeNull();
+  });
+
+  it("pairs each cycle with its own post-GC reading, not with the baseline", () => {
+    // A series that only looks like a gap when misaligned by one must not fire.
+    const rising = samples({ heap: [20, 30, 40, 50, 60, 70] });
+    const postGc = samples({ heap: [10, 20, 30, 40, 50, 60, 70] });
+
+    expect(
+      assessUnreclaimedRetention({
+        unreclaimedSamples: rising,
+        memorySamples: postGc,
+        verdict: "stable",
+        verdictIsWellSupported: true,
+      })
+    ).toBeNull();
+  });
+
+  it("ignores cycles with no matching post-GC reading", () => {
+    const retention = assessUnreclaimedRetention({
+      unreclaimedSamples: ISSUE_96533.unreclaimed,
+      memorySamples: samples({ heap: [27.1, 26.3, 27.3] }),
+      verdict: "stable",
+      verdictIsWellSupported: true,
+    });
+
+    // Only two cycles pair up; the rule still runs on what it has.
+    expect(retention === null || retention.medianGapBytes > 0).toBe(true);
   });
 });
 
 describe("describeUnreclaimedRetention", () => {
-  it("states the rate, the class and its own limits", () => {
+  it("states the gap, the class and its own limits", () => {
+    const line = describeUnreclaimedRetention({
+      class: "arrayBuffers",
+      medianGapBytes: 3.96 * MB,
+      retainedBytes: 0.32 * MB,
+      ratio: 3.96,
+    });
+
+    expect(line).toContain("3.96 MB of arrayBuffers");
+    expect(line).toContain("4.0x what it retains");
+    expect(line).toContain("a forced GC reclaims this");
+    expect(line).toContain("seconds after load");
+  });
+
+  it("labels external memory readably", () => {
     const line = describeUnreclaimedRetention({
       class: "external",
-      growthPerCycle: 10 * MB,
-      growthPer1000Requests: 5 * MB,
+      medianGapBytes: 5 * MB,
+      retainedBytes: 2 * MB,
+      ratio: 2.5,
     });
 
     expect(line).toContain("external memory");
-    expect(line).toContain("5.00 MB/1000 req");
-    // Never contradicts the verdict beside it, and never overstates itself.
-    expect(line).toContain("a forced GC reclaims this");
-    expect(line).toContain("seconds after load");
-    expect(line).toContain("while staying flat after it");
-  });
-
-  it("names the heap when the heap is what grew", () => {
-    const line = describeUnreclaimedRetention({
-      class: "heap",
-      growthPerCycle: 4 * MB,
-      growthPer1000Requests: 2 * MB,
-    });
-
-    expect(line).toContain("heap grew 2.00 MB/1000 req");
-    expect(line).not.toContain("external memory");
   });
 });

--- a/src/unreclaimed-retention.ts
+++ b/src/unreclaimed-retention.ts
@@ -58,20 +58,13 @@ const MIN_GAP_BYTES = 2 * MB;
 /**
  * And it must be this large relative to what the route actually retains.
  *
- * The absolute floor alone does not separate the classes, and the measurements
- * say so plainly — the deliberately leaky fixture holds *more* arrayBuffers
- * between collections (4.91 MB) than the vercel/next.js#96533 reproduction does
- * (3.95 MB). What distinguishes this class is holding much more than survives a
- * collection:
- *
- * | app                      | largest heap gap | ratio |
- * |--------------------------|------------------|-------|
- * | healthy fixture route    | 1.9 MB           | 0.27x |
- * | deliberately leaky route | 5.9 MB           | 0.06x |
- * | #96533 reproduction      | 24.8 MB          | 0.89x |
- *
- * The leaky route clears the floor and fails this, correctly: its memory really
- * is retained after a GC, which is what makes it a leak rather than this.
+ * An absolute floor alone does not separate the classes: the deliberately leaky
+ * fixture holds *more* arrayBuffers between collections (4.91 MB) than the
+ * vercel/next.js#96533 reproduction does (3.95 MB). What distinguishes this
+ * class is holding much more than survives a collection. Measured 2026-08-18:
+ * healthy 1.9 MB (0.27x), the leaky fixture 5.9 MB (0.06x), #96533 24.8 MB
+ * (0.89x). The leaky route clears the floor and fails the ratio, correctly —
+ * its memory really is retained after a GC, which is what makes it a leak.
  */
 const MIN_GAP_RATIO = 0.35;
 
@@ -92,21 +85,14 @@ const read = (sample: HeapSample, memoryClass: MemoryClass): number =>
 /**
  * The largest gap observed, which is a lower bound on what the process holds.
  *
- * Neither a mean nor a median. The pre-collection series is sampled with no
- * collection control, so a cycle where V8 happened to collect just before the
- * reading shows a gap of zero — and that says nothing about the app, only about
- * the timing of the sample. Three runs of the same #96533 reproduction:
- *
- *   run 1  3.79  0.00  4.71  4.12  3.03  5.40   median 3.96
- *   run 2                                        median 2.47
- *   run 3  0.00  1.49  0.00  0.00  3.79  0.00   median 0.00
- *
- * A median survives one collapsed cycle and not four, so on run 3 it would
- * report nothing about an app that demonstrably held 3.79 MB. A cycle that
- * *did* hold memory proves the process can; a cycle that held none proves only
- * that it had just been collected. The maximum answers the question actually
- * being asked, and understates rather than overstates: a gap larger than any
- * sampled one may well exist between samples.
+ * Neither a mean nor a median. The series is sampled with no collection
+ * control, so a cycle where V8 collected just before the reading shows a gap of
+ * zero — which says nothing about the app, only about the timing. Three runs of
+ * the #96533 repro gave medians of 3.96, 2.47 and 0.00 MB, the last because
+ * four of its six cycles collapsed that way. A cycle that *did* hold memory
+ * proves the process can; one that held none proves only that it had just been
+ * collected. The maximum understates rather than overstates: a larger gap may
+ * well exist between samples.
  */
 function largestGap(values: readonly number[]): number {
   return values.reduce((highest, value) => Math.max(highest, value), 0);
@@ -130,27 +116,17 @@ function gapsFor(input: UnreclaimedRetentionInput, memoryClass: MemoryClass): nu
  * Whether a route holds materially more memory between collections than it
  * retains after one.
  *
- * This is the shape of vercel/next.js#96533: the reporter measured 1.16 GB of
- * arrayBuffers accumulated over four days against a flat JS heap, and named the
- * mechanism — RSC buffers rooted through a module-scope WeakMap for as long as
- * the params key object stays reachable, on a process whose full GCs are rare.
+ * The shape of vercel/next.js#96533, where the reporter accumulated 1.16 GB of
+ * arrayBuffers over four days against a flat JS heap. Measured on that repro
+ * 2026-08-18, the signal is a *gap*, not a slope: arrayBuffers sat at 4–5 MB
+ * between collections against a flat 0.32 MB after one, while the series itself
+ * oscillated (+21.2, -3.0, -6.2, +14.2 MB) and classified as `inconclusive`. An
+ * earlier version keyed on that series climbing and reported nothing at all.
  *
- * Measured on that reproduction on 2026-08-18, the signal is a *gap*, not a
- * slope: arrayBuffers sat at 4–5 MB between collections against a flat 0.32 MB
- * after one, while the pre-collection series itself oscillated
- * (+21.2, -3.0, -6.2, +14.2 MB) and classified as `inconclusive`. An earlier
- * version of this rule keyed on that series climbing and therefore reported
- * nothing at all.
- *
- * Deliberately outside the verdict, like the peak-pressure note: `leak` /
- * `stable` / `inconclusive` are statements about what survives collection, and
- * this is a statement about what precedes it.
- *
- * Silent when the route already leaks *and* the evidence plainly supports it —
- * the retention is the headline there, and a note restating it in weaker terms
- * is noise. A marginal `leak` carrying low-confidence warnings does not silence
- * it: on the #96533 reproduction that weak verdict was hiding the finding that
- * actually names the mechanism.
+ * Outside the verdict, like the peak-pressure note: those are statements about
+ * what survives collection, this is one about what precedes it. Silent when the
+ * route already leaks on evidence that supports it — but a marginal `leak` does
+ * not silence it, since on #96533 that weak verdict was hiding this finding.
  */
 export function assessUnreclaimedRetention(
   input: UnreclaimedRetentionInput

--- a/src/unreclaimed-retention.ts
+++ b/src/unreclaimed-retention.ts
@@ -1,0 +1,75 @@
+import type { TrendResult, TrendVerdict } from "./trend.js";
+
+const MB = 1024 * 1024;
+
+export type UnreclaimedRetention = {
+  /** Which memory class grew before collection. */
+  class: "heap" | "external";
+  /** Mean growth per cycle (bytes) of the pre-collection series. */
+  growthPerCycle: number;
+  /** The same growth normalized to the traffic each cycle served. */
+  growthPer1000Requests: number;
+};
+
+export type UnreclaimedRetentionInput = {
+  /** Trend over the samples taken before any forced collection. */
+  unreclaimedTrend: TrendResult;
+  /** The route's own verdict, computed from the post-GC series. */
+  verdict: TrendVerdict;
+  requestsPerCycle: number;
+};
+
+/**
+ * Whether a route holds memory that a forced GC takes back — and that a
+ * production process may never run one often enough to take back.
+ *
+ * This is the shape of vercel/next.js#96533: the reporter measured 1.16 GB of
+ * `arrayBuffers` accumulated over four days against a flat JS heap, and named
+ * the mechanism — buffers rooted through a module-scope WeakMap for as long as
+ * the params key object stays reachable, on a process whose full GCs are rare.
+ * Every number this tool reports is taken after three forced collections, so
+ * that class of leak is invisible to the verdict by construction.
+ *
+ * Deliberately outside the verdict, like the peak-pressure note: `leak` /
+ * `stable` / `inconclusive` are statements about what survives collection, and
+ * this is a statement about what precedes it.
+ *
+ * Silent when the route already leaks — the retention is the headline there,
+ * and a note repeating it in weaker terms is noise. Silent, too, when the
+ * pre-collection series is merely undecided: that series is noisy by nature
+ * (nothing has been collected), and only a series that grows on every cycle is
+ * worth interrupting a run for.
+ */
+export function assessUnreclaimedRetention(
+  input: UnreclaimedRetentionInput
+): UnreclaimedRetention | null {
+  if (input.verdict === "leak" || input.unreclaimedTrend.verdict !== "leak") {
+    return null;
+  }
+  const growthPerCycle = input.unreclaimedTrend.growthPerCycle;
+  if (growthPerCycle <= 0 || input.requestsPerCycle <= 0) {
+    return null;
+  }
+  return {
+    class: input.unreclaimedTrend.source === "external" ? "external" : "heap",
+    growthPerCycle,
+    growthPer1000Requests: (growthPerCycle / input.requestsPerCycle) * 1000,
+  };
+}
+
+const mb = (bytes: number): string => `${(bytes / MB).toFixed(2)} MB`;
+
+/**
+ * One line, phrased so it never contradicts the verdict next to it, and so it
+ * states its own limit: this reading is taken seconds after load, not the hours
+ * a production process runs between full collections.
+ */
+export function describeUnreclaimedRetention(retention: UnreclaimedRetention): string {
+  const where = retention.class === "external" ? "external memory" : "heap";
+  return (
+    `${where} grew ${mb(retention.growthPer1000Requests)}/1000 req before collection ` +
+    `while staying flat after it — a forced GC reclaims this, a long-running ` +
+    `process may not run one often enough to; read seconds after load, so it ` +
+    `also includes memory not yet collected`
+  );
+}

--- a/src/unreclaimed-retention.ts
+++ b/src/unreclaimed-retention.ts
@@ -1,75 +1,207 @@
-import type { TrendResult, TrendVerdict } from "./trend.js";
+import type { HeapSample } from "./control-server.js";
+import type { TrendVerdict } from "./trend.js";
 
 const MB = 1024 * 1024;
 
+/**
+ * Memory classes compared between the two series, least to most specific.
+ *
+ * `arrayBuffers` is a subset of `external`, so when both are equally out of
+ * proportion the later one wins the tie below — naming the narrower class says
+ * more about the mechanism.
+ */
+const CLASSES = ["heap", "external", "arrayBuffers"] as const;
+
+export type MemoryClass = (typeof CLASSES)[number];
+
 export type UnreclaimedRetention = {
-  /** Which memory class grew before collection. */
-  class: "heap" | "external";
-  /** Mean growth per cycle (bytes) of the pre-collection series. */
-  growthPerCycle: number;
-  /** The same growth normalized to the traffic each cycle served. */
-  growthPer1000Requests: number;
+  /** Where holding-versus-retaining was most out of proportion. */
+  class: MemoryClass;
+  /** Median per-cycle gap between what was held and what survived a GC. */
+  medianGapBytes: number;
+  /** What the route retained after collection, in that class. */
+  retainedBytes: number;
+  /** The gap as a multiple of what is retained. */
+  ratio: number;
 };
 
 export type UnreclaimedRetentionInput = {
-  /** Trend over the samples taken before any forced collection. */
-  unreclaimedTrend: TrendResult;
+  /** One reading per cycle, taken before any forced collection. */
+  unreclaimedSamples: readonly HeapSample[];
+  /** Post-GC samples: baseline first, then one per cycle. */
+  memorySamples: readonly HeapSample[];
   /** The route's own verdict, computed from the post-GC series. */
   verdict: TrendVerdict;
-  requestsPerCycle: number;
+  /**
+   * Whether that `leak` verdict is one the evidence plainly supports — the same
+   * bar an issue draft has to clear.
+   *
+   * A weak `leak` must not silence this note. Measured on the #96533
+   * reproduction: the post-GC verdict is `leak` at +0.15 MB/1000 req carrying
+   * two low-confidence warnings, which is noise grazing the threshold, while
+   * the gap is 3.96 MB of arrayBuffers at 4x what the route retains. Silencing
+   * on any `leak` at all let the weaker finding hide the stronger one.
+   */
+  verdictIsWellSupported: boolean;
 };
 
 /**
- * Whether a route holds memory that a forced GC takes back — and that a
- * production process may never run one often enough to take back.
+ * The gap must clear this in absolute terms before it is worth saying.
+ *
+ * Measured 2026-08-18: a healthy route's median gap is 0.77 MB. Below a floor
+ * like this the note would fire on every small app, and on a route retaining
+ * almost nothing the ratio below is meaningless on its own.
+ */
+const MIN_GAP_BYTES = 2 * MB;
+
+/**
+ * And it must be this large relative to what the route actually retains.
+ *
+ * The absolute floor alone does not separate the classes, and the measurements
+ * say so plainly — the deliberately leaky fixture holds *more* arrayBuffers
+ * between collections (4.91 MB) than the vercel/next.js#96533 reproduction does
+ * (3.95 MB). What distinguishes this class is holding much more than survives a
+ * collection:
+ *
+ * | app                      | median heap gap | ratio |
+ * |--------------------------|-----------------|-------|
+ * | healthy fixture route    | 0.77 MB         | 0.11x |
+ * | deliberately leaky route | 5.13 MB         | 0.21x |
+ * | #96533 reproduction      | 18.8 MB         | 0.70x |
+ *
+ * The leaky route clears the floor and fails this, correctly: its memory really
+ * is retained after a GC, which is what makes it a leak rather than this.
+ */
+const MIN_GAP_RATIO = 0.35;
+
+/**
+ * Floor for the denominator, so a class retaining almost nothing does not
+ * produce an infinite ratio. #96533 retains 0.32 MB of arrayBuffers while
+ * holding 3.95 MB between collections; without this the ratio is unbounded.
+ */
+const MIN_RETAINED_BYTES = MB;
+
+const read = (sample: HeapSample, memoryClass: MemoryClass): number =>
+  memoryClass === "heap"
+    ? sample.heapUsed
+    : memoryClass === "external"
+      ? sample.external
+      : sample.arrayBuffers;
+
+/**
+ * Middle of the sorted values, averaging the two central ones when even.
+ *
+ * A median rather than a mean because the pre-collection series is sampled with
+ * no collection control: on the #96533 run, one cycle of six fell all the way
+ * back to the post-GC level because V8 collected on its own just before the
+ * reading. A mean lets that one cycle drag the finding down; a median does not.
+ */
+function median(values: readonly number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) {
+    return sorted[middle] ?? 0;
+  }
+  return ((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2;
+}
+
+/** Per-cycle gaps for one memory class, pairing cycle i with cycle i. */
+function gapsFor(input: UnreclaimedRetentionInput, memoryClass: MemoryClass): number[] {
+  const gaps: number[] = [];
+  for (const [index, held] of input.unreclaimedSamples.entries()) {
+    // memorySamples[0] is the baseline, so cycle i sits at index i + 1.
+    const afterGc = input.memorySamples[index + 1];
+    if (afterGc === undefined) {
+      break;
+    }
+    gaps.push(read(held, memoryClass) - read(afterGc, memoryClass));
+  }
+  return gaps;
+}
+
+/**
+ * Whether a route holds materially more memory between collections than it
+ * retains after one.
  *
  * This is the shape of vercel/next.js#96533: the reporter measured 1.16 GB of
- * `arrayBuffers` accumulated over four days against a flat JS heap, and named
- * the mechanism — buffers rooted through a module-scope WeakMap for as long as
+ * arrayBuffers accumulated over four days against a flat JS heap, and named the
+ * mechanism — RSC buffers rooted through a module-scope WeakMap for as long as
  * the params key object stays reachable, on a process whose full GCs are rare.
- * Every number this tool reports is taken after three forced collections, so
- * that class of leak is invisible to the verdict by construction.
+ *
+ * Measured on that reproduction on 2026-08-18, the signal is a *gap*, not a
+ * slope: arrayBuffers sat at 4–5 MB between collections against a flat 0.32 MB
+ * after one, while the pre-collection series itself oscillated
+ * (+21.2, -3.0, -6.2, +14.2 MB) and classified as `inconclusive`. An earlier
+ * version of this rule keyed on that series climbing and therefore reported
+ * nothing at all.
  *
  * Deliberately outside the verdict, like the peak-pressure note: `leak` /
  * `stable` / `inconclusive` are statements about what survives collection, and
  * this is a statement about what precedes it.
  *
- * Silent when the route already leaks — the retention is the headline there,
- * and a note repeating it in weaker terms is noise. Silent, too, when the
- * pre-collection series is merely undecided: that series is noisy by nature
- * (nothing has been collected), and only a series that grows on every cycle is
- * worth interrupting a run for.
+ * Silent when the route already leaks *and* the evidence plainly supports it —
+ * the retention is the headline there, and a note restating it in weaker terms
+ * is noise. A marginal `leak` carrying low-confidence warnings does not silence
+ * it: on the #96533 reproduction that weak verdict was hiding the finding that
+ * actually names the mechanism.
  */
 export function assessUnreclaimedRetention(
   input: UnreclaimedRetentionInput
 ): UnreclaimedRetention | null {
-  if (input.verdict === "leak" || input.unreclaimedTrend.verdict !== "leak") {
+  if (
+    (input.verdict === "leak" && input.verdictIsWellSupported) ||
+    input.unreclaimedSamples.length === 0
+  ) {
     return null;
   }
-  const growthPerCycle = input.unreclaimedTrend.growthPerCycle;
-  if (growthPerCycle <= 0 || input.requestsPerCycle <= 0) {
-    return null;
+
+  let worst: UnreclaimedRetention | null = null;
+  for (const memoryClass of CLASSES) {
+    const gaps = gapsFor(input, memoryClass);
+    if (gaps.length === 0) {
+      continue;
+    }
+    const medianGapBytes = median(gaps);
+    if (medianGapBytes < MIN_GAP_BYTES) {
+      continue;
+    }
+    const retainedBytes = median(
+      input.memorySamples.slice(1).map((sample) => read(sample, memoryClass))
+    );
+    const ratio = medianGapBytes / Math.max(retainedBytes, MIN_RETAINED_BYTES);
+    if (ratio < MIN_GAP_RATIO) {
+      continue;
+    }
+    // Report where the disproportion is largest, not where the megabytes are:
+    // that is what names the mechanism.
+    if (worst === null || ratio >= worst.ratio) {
+      worst = { class: memoryClass, medianGapBytes, retainedBytes, ratio };
+    }
   }
-  return {
-    class: input.unreclaimedTrend.source === "external" ? "external" : "heap",
-    growthPerCycle,
-    growthPer1000Requests: (growthPerCycle / input.requestsPerCycle) * 1000,
-  };
+  return worst;
 }
 
 const mb = (bytes: number): string => `${(bytes / MB).toFixed(2)} MB`;
 
+const CLASS_LABEL: Record<MemoryClass, string> = {
+  heap: "heap",
+  external: "external memory",
+  arrayBuffers: "arrayBuffers",
+};
+
 /**
- * One line, phrased so it never contradicts the verdict next to it, and so it
- * states its own limit: this reading is taken seconds after load, not the hours
+ * One line, phrased so it never contradicts the verdict beside it, and so it
+ * states its own limit: the reading is taken seconds after load, not the hours
  * a production process runs between full collections.
  */
 export function describeUnreclaimedRetention(retention: UnreclaimedRetention): string {
-  const where = retention.class === "external" ? "external memory" : "heap";
   return (
-    `${where} grew ${mb(retention.growthPer1000Requests)}/1000 req before collection ` +
-    `while staying flat after it — a forced GC reclaims this, a long-running ` +
-    `process may not run one often enough to; read seconds after load, so it ` +
-    `also includes memory not yet collected`
+    `held ${mb(retention.medianGapBytes)} of ${CLASS_LABEL[retention.class]} between ` +
+    `collections that a GC took back (${retention.ratio.toFixed(1)}x what it retains) — ` +
+    `a forced GC reclaims this, a long-running process may not run one often ` +
+    `enough to; read seconds after load, so it also includes memory not yet collected`
   );
 }

--- a/src/unreclaimed-retention.ts
+++ b/src/unreclaimed-retention.ts
@@ -17,8 +17,8 @@ export type MemoryClass = (typeof CLASSES)[number];
 export type UnreclaimedRetention = {
   /** Where holding-versus-retaining was most out of proportion. */
   class: MemoryClass;
-  /** Median per-cycle gap between what was held and what survived a GC. */
-  medianGapBytes: number;
+  /** Largest per-cycle gap between what was held and what survived a GC. */
+  largestGapBytes: number;
   /** What the route retained after collection, in that class. */
   retainedBytes: number;
   /** The gap as a multiple of what is retained. */
@@ -48,9 +48,10 @@ export type UnreclaimedRetentionInput = {
 /**
  * The gap must clear this in absolute terms before it is worth saying.
  *
- * Measured 2026-08-18: a healthy route's median gap is 0.77 MB. Below a floor
+ * Measured 2026-08-18: a healthy route's largest gap is 1.9 MB. Below a floor
  * like this the note would fire on every small app, and on a route retaining
- * almost nothing the ratio below is meaningless on its own.
+ * almost nothing the ratio below is meaningless on its own. The margin here is
+ * thin — the ratio below is what actually keeps the healthy app quiet.
  */
 const MIN_GAP_BYTES = 2 * MB;
 
@@ -63,11 +64,11 @@ const MIN_GAP_BYTES = 2 * MB;
  * (3.95 MB). What distinguishes this class is holding much more than survives a
  * collection:
  *
- * | app                      | median heap gap | ratio |
- * |--------------------------|-----------------|-------|
- * | healthy fixture route    | 0.77 MB         | 0.11x |
- * | deliberately leaky route | 5.13 MB         | 0.21x |
- * | #96533 reproduction      | 18.8 MB         | 0.70x |
+ * | app                      | largest heap gap | ratio |
+ * |--------------------------|------------------|-------|
+ * | healthy fixture route    | 1.9 MB           | 0.27x |
+ * | deliberately leaky route | 5.9 MB           | 0.06x |
+ * | #96533 reproduction      | 24.8 MB          | 0.89x |
  *
  * The leaky route clears the floor and fails this, correctly: its memory really
  * is retained after a GC, which is what makes it a leak rather than this.
@@ -89,23 +90,26 @@ const read = (sample: HeapSample, memoryClass: MemoryClass): number =>
       : sample.arrayBuffers;
 
 /**
- * Middle of the sorted values, averaging the two central ones when even.
+ * The largest gap observed, which is a lower bound on what the process holds.
  *
- * A median rather than a mean because the pre-collection series is sampled with
- * no collection control: on the #96533 run, one cycle of six fell all the way
- * back to the post-GC level because V8 collected on its own just before the
- * reading. A mean lets that one cycle drag the finding down; a median does not.
+ * Neither a mean nor a median. The pre-collection series is sampled with no
+ * collection control, so a cycle where V8 happened to collect just before the
+ * reading shows a gap of zero — and that says nothing about the app, only about
+ * the timing of the sample. Three runs of the same #96533 reproduction:
+ *
+ *   run 1  3.79  0.00  4.71  4.12  3.03  5.40   median 3.96
+ *   run 2                                        median 2.47
+ *   run 3  0.00  1.49  0.00  0.00  3.79  0.00   median 0.00
+ *
+ * A median survives one collapsed cycle and not four, so on run 3 it would
+ * report nothing about an app that demonstrably held 3.79 MB. A cycle that
+ * *did* hold memory proves the process can; a cycle that held none proves only
+ * that it had just been collected. The maximum answers the question actually
+ * being asked, and understates rather than overstates: a gap larger than any
+ * sampled one may well exist between samples.
  */
-function median(values: readonly number[]): number {
-  if (values.length === 0) {
-    return 0;
-  }
-  const sorted = [...values].sort((a, b) => a - b);
-  const middle = Math.floor(sorted.length / 2);
-  if (sorted.length % 2 === 1) {
-    return sorted[middle] ?? 0;
-  }
-  return ((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2;
+function largestGap(values: readonly number[]): number {
+  return values.reduce((highest, value) => Math.max(highest, value), 0);
 }
 
 /** Per-cycle gaps for one memory class, pairing cycle i with cycle i. */
@@ -164,21 +168,21 @@ export function assessUnreclaimedRetention(
     if (gaps.length === 0) {
       continue;
     }
-    const medianGapBytes = median(gaps);
-    if (medianGapBytes < MIN_GAP_BYTES) {
+    const largestGapBytes = largestGap(gaps);
+    if (largestGapBytes < MIN_GAP_BYTES) {
       continue;
     }
-    const retainedBytes = median(
+    const retainedBytes = largestGap(
       input.memorySamples.slice(1).map((sample) => read(sample, memoryClass))
     );
-    const ratio = medianGapBytes / Math.max(retainedBytes, MIN_RETAINED_BYTES);
+    const ratio = largestGapBytes / Math.max(retainedBytes, MIN_RETAINED_BYTES);
     if (ratio < MIN_GAP_RATIO) {
       continue;
     }
     // Report where the disproportion is largest, not where the megabytes are:
     // that is what names the mechanism.
     if (worst === null || ratio >= worst.ratio) {
-      worst = { class: memoryClass, medianGapBytes, retainedBytes, ratio };
+      worst = { class: memoryClass, largestGapBytes, retainedBytes, ratio };
     }
   }
   return worst;
@@ -199,7 +203,7 @@ const CLASS_LABEL: Record<MemoryClass, string> = {
  */
 export function describeUnreclaimedRetention(retention: UnreclaimedRetention): string {
   return (
-    `held ${mb(retention.medianGapBytes)} of ${CLASS_LABEL[retention.class]} between ` +
+    `held ${mb(retention.largestGapBytes)} of ${CLASS_LABEL[retention.class]} between ` +
     `collections that a GC took back (${retention.ratio.toFixed(1)}x what it retains) — ` +
     `a forced GC reclaims this, a long-running process may not run one often ` +
     `enough to; read seconds after load, so it also includes memory not yet collected`

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -40,7 +40,15 @@
     "src/load.ts",
     "src/control-server.ts",
     "src/launcher.ts",
-    "src/control-client.ts"
+    "src/control-client.ts",
+    "src/isr.ts",
+    "src/route-guidance.ts",
+    "src/unreclaimed-retention.ts",
+    "src/process-tree.ts",
+    "src/build-verdict.ts",
+    "src/build-target.ts",
+    "src/build-run.ts",
+    "src/build-report.ts"
   ],
   "thresholds": {
     "high": 90,


### PR DESCRIPTION
Two days of measuring the tool against public reproductions of open Next.js
issues, and fixing what that turned up.

## What was wrong

The tool was accurate on the apps it was calibrated against and quietly wrong
on the apps a stranger would point it at. Four silent false negatives, each one
measured rather than suspected:

- A route whose growth is 85x the gate came back `stable`, because two of five
  deltas were negative. The harder a route leaks, the noisier the forced GC
  makes the curve, so the failure got worse as the leak got worse.
- ISR routes served their cache and never re-rendered. Same app, same build:
  `leak` with the revalidation header, `stable` without it, and nothing in the
  output hinted the route had not been exercised.
- A dynamic route was skipped with one line naming a config file, leaving the
  user to work out its shape. On a repro whose only route is dynamic, that was
  a run that measured nothing and explained nothing.
- A run that measured no route at all exited 0, which in CI reads as "your app
  is fine".

## What is new

- `next-leak build <dir>` measures the build instead of a built server, where
  large sites run out of heap while prerendering (#97464).
- Each cycle is read twice, before and after collection, and the gap between
  them is reported. That is the shape of #96533, invisible to a post-GC verdict
  by construction.
- Bounded key cardinality (`{n%200}`), the shape the reported leaks actually
  have, alongside the existing unbounded `{n}`.
- Saturation is told apart from a route returning errors, and named with the
  knob that addresses it.
- The report says how much of the app it covered, and warns when the baseline
  is carrying warm-up's own memory.

## Verification

626 tests, three consecutive runs without flakiness, types clean, build, bundle
check and pack smoke green. Mutation on the six modules carrying new decisions:
93.9% / 92.1% / 88.9% / 86.3% / 84.5% / 82.7%, none regressed.

Measured end to end against four public reproductions from clean clones:

| repro | outcome |
|---|---|
| #96533 | `leak`, ISR driven by the tool, mechanism named |
| #97464 | `leak` via `next-leak build`, OOM after 1252 pages, reproducible |
| #97424 | `stable` with the peak-pressure and unreclaimed notes naming its failure mode |
| healthy app | `stable` and `leak` correct, no note fired |

That exercise found a defect no unit test had: a 1.7 GB heap snapshot cannot be
read into a single string, and the resulting `RangeError` took a finished
measurement down with the whole run. Both the size refusal and the wrapped diff
are in here.

## Docs

The README led with four issues described as open; three closed in 16.3.0 on
2026-08-03. States re-checked against GitHub, and #89091 re-measured on 16.3.1:
it no longer reproduces (+42.5 → +0.03 MB per 1000 aborted requests), almost
certainly #96173. The `ISSUE-<route>.md` promise now states both conditions the
code applies.
