### PR TITLE
feat: let a route cut its clients before the response starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,10 +167,19 @@ first try. When a run skips a route it prints the same fragment.
   load-balancer timeouts and bots do. Some leaks only exist on that path
   (`ServerResponse` retained after an early disconnect; the RSC tee branch in
   [#94919](https://github.com/vercel/next.js/issues/94919)). The clock starts
-  at the **first byte of the response**, not at the request — under load a
-  request-relative window cuts before the stream begins and tests a different
-  path. Small values are the point: `4` means "read the first chunk, then
-  vanish". Requests abandoned on purpose are not counted as failures.
+  at the **first byte of the response**, so the cut lands mid-stream however
+  long the route takes to answer. Small values are the point: `4` means "read
+  the first chunk, then vanish". Requests abandoned on purpose are not counted
+  as failures.
+- **`abandonFrom`** moves that clock to the request itself
+  (`"abandonFrom": "request"`). Use it for the opposite experiment: a client
+  that is already gone before the server produces anything. On a route slower
+  than the deadline the default never cuts early — against the reproduction
+  for [#84648](https://github.com/vercel/next.js/issues/84648), whose upstream
+  answers in 400 ms while its load generator cuts at 60 ms, first-byte reached
+  7% of requests and `request` reached all of them. It stays opt-in because a
+  deadline armed on connect loses the race to the first byte on fast routes,
+  which measures the wrong path silently.
 
 `run.json` records what every load phase actually did — requests sent,
 2xx, abandoned — so a run can be audited instead of trusted.

--- a/src/abandon-load.test.ts
+++ b/src/abandon-load.test.ts
@@ -335,4 +335,91 @@ describe("mid-stream abandonment", () => {
     expect(result.completed).toBe(20);
     expect(result.abandoned).toBe(0);
   }, 60_000);
+
+  // The pair below is the whole point of the request origin: same server, same
+  // deadline, opposite outcomes. Modelled on the vercel/next.js#84648 repro,
+  // whose upstream answers well after the window its own load generator uses.
+  describe("abandonFrom: request", () => {
+    const slowFirstByte: http.RequestListener = (_req, res) => {
+      setTimeout(() => res.end("late"), 2000).unref();
+    };
+
+    it("cuts before the first byte on a route that has not started answering", async () => {
+      const port = await listen(slowFirstByte);
+
+      const result = await runAbandonPhase({
+        url: `http://127.0.0.1:${port}/slow`,
+        amount: 6,
+        connections: 3,
+        abandonAfterMs: 40,
+        abandonFrom: "request",
+      });
+
+      expect(result.abandoned).toBe(6);
+      expect(result.abandonedBeforeResponse).toBe(6);
+      expect(result.abandonedMidStream).toBe(0);
+      expect(result.completed).toBe(0);
+    }, 60_000);
+
+    it("leaves that same route untouched under the default origin", async () => {
+      const port = await listen(slowFirstByte);
+
+      const result = await runAbandonPhase({
+        url: `http://127.0.0.1:${port}/slow`,
+        amount: 6,
+        connections: 3,
+        abandonAfterMs: 40,
+      });
+
+      // The deadline never arms: the first byte arrives at 2s, inside the
+      // first-byte budget, and the response completes immediately after.
+      expect(result.abandoned).toBe(0);
+      expect(result.completed).toBe(6);
+    }, 60_000);
+
+    it("still counts a cut as mid-stream when bytes had arrived", async () => {
+      const port = await listen((_req, res) => {
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.write("chunk");
+        setTimeout(() => res.end("late"), 30_000).unref();
+      });
+
+      const result = await runAbandonPhase({
+        url: `http://127.0.0.1:${port}/streaming`,
+        amount: 6,
+        connections: 3,
+        abandonAfterMs: 60,
+        abandonFrom: "request",
+      });
+
+      expect(result.abandoned).toBe(6);
+      expect(result.abandonedMidStream).toBe(6);
+      expect(result.abandonedBeforeResponse).toBe(0);
+    }, 60_000);
+
+    it("does not restart the deadline when the first byte arrives", async () => {
+      // Answers at 60ms with a body it never finishes. Under the first-byte
+      // origin the cut would land 400ms after that byte; under this one it
+      // must land 100ms after the request, so ~40ms after the byte.
+      const port = await listen((_req, res) => {
+        setTimeout(() => {
+          res.writeHead(200, { "content-type": "text/plain" });
+          res.write("chunk");
+        }, 60).unref();
+        setTimeout(() => res.end("late"), 30_000).unref();
+      });
+
+      const started = Date.now();
+      const result = await runAbandonPhase({
+        url: `http://127.0.0.1:${port}/streaming`,
+        amount: 3,
+        connections: 3,
+        abandonAfterMs: 100,
+        abandonFrom: "request",
+      });
+
+      expect(result.abandoned).toBe(3);
+      expect(Date.now() - started).toBeLessThan(400);
+    }, 60_000);
+  });
 });

--- a/src/abandon-load.ts
+++ b/src/abandon-load.ts
@@ -1,11 +1,20 @@
 import net from "node:net";
 
+/**
+ * Where the abandon deadline starts. `first-byte` puts the cut mid-stream
+ * whatever the route's latency; `request` puts it before the response exists,
+ * which is a different leak path and not reachable from the other origin.
+ */
+export type AbandonOrigin = "first-byte" | "request";
+
 export type AbandonPhaseOptions = {
   url: string;
   amount: number;
   connections: number;
-  /** Destroy the socket this many ms after the first byte of the response. */
+  /** Destroy the socket this many ms after the origin below. */
   abandonAfterMs: number;
+  /** Defaults to `first-byte`. */
+  abandonFrom?: AbandonOrigin;
   headers?: Record<string, string>;
 };
 
@@ -44,13 +53,16 @@ const FIRST_BYTE_BUDGET_MS = 5000;
  * a client goes away mid-flight (closed tabs, load-balancer timeouts, bots).
  *
  * Raw sockets keep this honest: write the request, wait for the response to
- * start, then wait `abandonAfterMs` and destroy the socket mid-stream.
+ * start, then wait `abandonAfterMs` and destroy the socket mid-stream. With
+ * `abandonFrom: "request"` the wait starts at the write instead, which is the
+ * only way to cut a route that has not begun answering yet.
  */
 export async function runAbandonPhase(
   options: AbandonPhaseOptions
 ): Promise<AbandonPhaseResult> {
   const target = new URL(options.url);
   const port = Number(target.port || 80);
+  const fromRequest = options.abandonFrom === "request";
   const headerLines = Object.entries(options.headers ?? {})
     .map(([name, value]) => `${name}: ${value}\r\n`)
     .join("");
@@ -97,15 +109,20 @@ export async function runAbandonPhase(
         finish();
       };
 
-      // Only the first-byte budget is armed here. An earlier version started
-      // the abandon window on connect, which raced the server's first byte —
-      // and under load the server lost that race almost every time: measured
-      // against the vercel/next.js#94919 repro, 2 of ~1500 cuts per cycle
-      // landed mid-stream. The window has to start where the stream does.
+      // Under the default origin only the first-byte budget is armed here. An
+      // earlier version always started the abandon window on connect, which
+      // raced the server's first byte — and under load the server lost that
+      // race almost every time: measured against the vercel/next.js#94919
+      // repro, 2 of ~1500 cuts per cycle landed mid-stream. That is why the
+      // window starts where the stream does unless a route asks otherwise,
+      // and why asking is per route rather than a default.
       socket.once("connect", () => {
         result.sent += 1;
         socket.write(request);
-        timer = setTimeout(giveUp, FIRST_BYTE_BUDGET_MS);
+        timer = setTimeout(
+          giveUp,
+          fromRequest ? options.abandonAfterMs : FIRST_BYTE_BUDGET_MS
+        );
         timer.unref();
       });
       // Receiving bytes is not the end of the experiment, it is the start of
@@ -117,6 +134,12 @@ export async function runAbandonPhase(
           return;
         }
         responseStarted = true;
+        // Under the request origin the deadline is already running from the
+        // write and must not be restarted here, or a route that answers just
+        // inside it would get a second full window and never be cut.
+        if (fromRequest) {
+          return;
+        }
         clearTimeout(timer);
         timer = setTimeout(giveUp, options.abandonAfterMs);
         timer.unref();

--- a/src/confidence.test.ts
+++ b/src/confidence.test.ts
@@ -228,6 +228,43 @@ describe("abandonment auditing", () => {
     expect(result.supersededVerdict).toBeUndefined();
     expect(codesOf(result)).toEqual(["abandon-ineffective"]);
   });
+
+  // Under the request origin a cut that lands before the response is the
+  // experiment, not a miss. Reporting it would teach the reader to skip the
+  // one warning here that still means something.
+  it("stays quiet on pre-response cuts when the route asked for them", () => {
+    const outcomes = [
+      {
+        phase: "cycle 1",
+        sent: 1000,
+        abandoned: 1000,
+        abandonedMidStream: 0,
+        abandonedBeforeResponse: 1000,
+      },
+    ];
+
+    const requested = assessConfidence(
+      input({ abandonAfterMs: 15, abandonFrom: "request" as const, loadOutcomes: outcomes })
+    );
+    const byDefault = assessConfidence(input({ abandonAfterMs: 15, loadOutcomes: outcomes }));
+
+    expect(codesOf(requested)).toEqual([]);
+    expect(codesOf(byDefault)).toEqual(["abandon-before-response"]);
+  });
+
+  it("still reports a shortfall under the request origin", () => {
+    const result = assessConfidence(
+      input({
+        abandonAfterMs: 15,
+        abandonFrom: "request" as const,
+        loadOutcomes: [
+          { phase: "cycle 1", sent: 1000, abandoned: 140, abandonedBeforeResponse: 140 },
+        ],
+      })
+    );
+
+    expect(codesOf(result)).toEqual(["abandon-ineffective"]);
+  });
 });
 
 describe("growth shape auditing", () => {

--- a/src/confidence.ts
+++ b/src/confidence.ts
@@ -1,3 +1,4 @@
+import type { AbandonOrigin } from "./abandon-load.js";
 import type { HeapSample } from "./control-server.js";
 import type { LoadOutcome, SettleOutcome } from "./ritual.js";
 import { MIN_GROWTH_NOISE_FLOOR, type TrendResult, type TrendVerdict } from "./trend.js";
@@ -55,6 +56,8 @@ export type ConfidenceInput = {
   settleOutcomes: readonly SettleOutcome[];
   /** Set when the run asked for early disconnects. */
   abandonAfterMs?: number;
+  /** Which deadline origin those disconnects used. Defaults to `first-byte`. */
+  abandonFrom?: AbandonOrigin;
   /** Threshold the verdict used, for the noise-floor check. */
   minGrowthPerCycle?: number;
   /** Post-GC samples, for the heap-ceiling check. */
@@ -161,7 +164,10 @@ function settleWarnings(outcomes: readonly SettleOutcome[]): MeasurementWarning[
   return warnings;
 }
 
-function abandonmentWarnings(outcome: LoadOutcome): MeasurementWarning[] {
+function abandonmentWarnings(
+  outcome: LoadOutcome,
+  abandonFrom: AbandonOrigin | undefined
+): MeasurementWarning[] {
   const abandoned = outcome.abandoned ?? 0;
   if (outcome.sent > 0 && abandoned < outcome.sent * ABANDON_EFFECTIVE_FLOOR) {
     return [{
@@ -181,6 +187,13 @@ function abandonmentWarnings(outcome: LoadOutcome): MeasurementWarning[] {
   // That advice was unfollowable — under load there is no such value — and it
   // is now moot: the deadline starts at the first byte. Landing here means the
   // route sent nothing at all within the first-byte budget.
+  // Under the request origin the cut is meant to land before the response
+  // exists — that is the whole reason a route selects it. Reporting the
+  // intended outcome as a shortfall would train the reader to ignore the one
+  // warning that still matters here, which is the effectiveness check above.
+  if (abandonFrom === "request") {
+    return [];
+  }
   const midStream = outcome.abandonedMidStream ?? 0;
   if (abandoned > 0 && midStream < abandoned * MID_STREAM_FLOOR) {
     return [{
@@ -197,12 +210,13 @@ function abandonmentWarnings(outcome: LoadOutcome): MeasurementWarning[] {
 
 function loadWarnings(
   outcomes: readonly LoadOutcome[],
-  abandonAfterMs: number | undefined
+  abandonAfterMs: number | undefined,
+  abandonFrom: AbandonOrigin | undefined
 ): MeasurementWarning[] {
   const warnings: MeasurementWarning[] = [];
   for (const outcome of outcomes) {
     if (abandonAfterMs !== undefined) {
-      warnings.push(...abandonmentWarnings(outcome));
+      warnings.push(...abandonmentWarnings(outcome, abandonFrom));
       continue;
     }
     const landed = outcome.ok2xx ?? 0;
@@ -429,7 +443,7 @@ export function assessConfidence(input: ConfidenceInput): ConfidenceReport {
   const minGrowth = input.minGrowthPerCycle ?? MIN_GROWTH_NOISE_FLOOR;
   const warnings = [
     ...settleWarnings(input.settleOutcomes),
-    ...loadWarnings(input.loadOutcomes, input.abandonAfterMs),
+    ...loadWarnings(input.loadOutcomes, input.abandonAfterMs, input.abandonFrom),
     ...growthShapeWarnings(input.trend),
     ...noiseFloorWarnings(input.trend, minGrowth),
     ...thinEvidenceWarnings(input.trend, minGrowth),

--- a/src/report.ts
+++ b/src/report.ts
@@ -72,6 +72,25 @@ function revalidationLines(route: MeasuredRouteView): string[] {
       ];
 }
 
+/**
+ * Which early-disconnect experiment ran. The counters below say what the cuts
+ * hit; this says what they were aiming at, and the two origins aim at
+ * different leaks — mid-stream teardown against a client that was never there
+ * at all.
+ */
+function abandonLines(route: MeasuredRouteView): string[] {
+  if (route.abandon === undefined) {
+    return [];
+  }
+  return [
+    route.abandon.from === "request"
+      ? `      cut ${route.abandon.afterMs}ms after the request was sent, so the ` +
+        `client is gone before the response starts`
+      : `      cut ${route.abandon.afterMs}ms after the first byte, so the cut ` +
+        `lands mid-stream`,
+  ];
+}
+
 function confidenceLines(route: MeasuredRouteView): string[] {
   const lines: string[] = [];
   // What the instrument thinks of its own reading. Silence here would be the
@@ -206,6 +225,7 @@ function routeLines(route: RouteReport, parameters: RunParameters): string[] {
       route.growthPer1000Requests
     )})  heap ${curve}${resolved}`,
     ...revalidationLines(route),
+    ...abandonLines(route),
     ...confidenceLines(route),
     ...memorySourceLines(route, verdict),
     ...peakPressureLines(route, parameters),

--- a/src/ritual.ts
+++ b/src/ritual.ts
@@ -2,7 +2,11 @@ import { mkdir } from "node:fs/promises";
 import { requestGc, requestMemory, requestSnapshot } from "./control-client.js";
 import type { HeapSample } from "./control-server.js";
 import { launchInstrumented } from "./launcher.js";
-import { runAbandonPhase, type AbandonPhaseResult } from "./abandon-load.js";
+import {
+  runAbandonPhase,
+  type AbandonOrigin,
+  type AbandonPhaseResult,
+} from "./abandon-load.js";
 import { runLoadPhase } from "./load.js";
 import { classifyMemoryTrend, minGrowthFor, type TrendResult } from "./trend.js";
 
@@ -27,6 +31,8 @@ export type RitualOptions = {
   headers?: Record<string, string>;
   /** Emulate clients that disconnect before the response arrives. */
   abandonAfterMs?: number;
+  /** Where that deadline starts. Defaults to `first-byte`. */
+  abandonFrom?: AbandonOrigin;
 };
 
 export type PhaseTiming = {
@@ -357,6 +363,7 @@ export async function runRitual(
       amount,
       connections,
       abandonAfterMs,
+      ...(options.abandonFrom !== undefined && { abandonFrom: options.abandonFrom }),
       ...(options.headers !== undefined && { headers: options.headers }),
     });
     loadOutcomes.push({

--- a/src/route-config.test.ts
+++ b/src/route-config.test.ts
@@ -131,6 +131,35 @@ describe("query strings and client abandonment", () => {
     await writeFile(path.join(dir, ROUTE_CONFIG_FILE), JSON.stringify({ abandonAfterMs: -5 }));
     await expect(loadRouteConfig(dir)).rejects.toBeInstanceOf(RouteConfigError);
   });
+
+  it("reads abandonFrom and defaults it to nothing", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "next-leak-config-"));
+    await writeFile(
+      path.join(dir, ROUTE_CONFIG_FILE),
+      JSON.stringify({ abandonAfterMs: 60, abandonFrom: "request" })
+    );
+    expect((await loadRouteConfig(dir)).abandonFrom).toBe("request");
+
+    await writeFile(path.join(dir, ROUTE_CONFIG_FILE), JSON.stringify({ abandonAfterMs: 60 }));
+    expect((await loadRouteConfig(dir)).abandonFrom).toBeUndefined();
+  });
+
+  it("rejects an unknown origin and one with no deadline to anchor", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "next-leak-config-"));
+    await writeFile(
+      path.join(dir, ROUTE_CONFIG_FILE),
+      JSON.stringify({ abandonAfterMs: 60, abandonFrom: "connect" })
+    );
+    await expect(loadRouteConfig(dir)).rejects.toBeInstanceOf(RouteConfigError);
+
+    // An origin with no deadline configures nothing, so it is a mistake worth
+    // naming rather than a no-op to swallow.
+    await writeFile(
+      path.join(dir, ROUTE_CONFIG_FILE),
+      JSON.stringify({ abandonFrom: "request" })
+    );
+    await expect(loadRouteConfig(dir)).rejects.toBeInstanceOf(RouteConfigError);
+  });
 });
 
 // `{n}` is unbounded by construction; the reported leaks turn on a fixed set of

--- a/src/route-config.ts
+++ b/src/route-config.ts
@@ -44,8 +44,29 @@ const routeConfigSchema = z
      * tests the wrong path entirely.
      */
     abandonAfterMs: z.number().int().positive().optional(),
+    /**
+     * Where the abandon deadline starts. `first-byte` is the default and the
+     * semantics everything else assumes.
+     *
+     * `request` starts it when the request is written, which is the only way
+     * to reach leaks that need the client already gone before the server
+     * produces anything: against a route whose time-to-first-byte exceeds the
+     * deadline, a first-byte clock never cuts early. Measured on the
+     * vercel/next.js#84648 repro, whose upstream answers in 400 ms while its
+     * own load generator cuts at 60 ms — the first-byte clock reached 7% of
+     * requests there, none of them on the path the issue describes.
+     *
+     * Opt-in per route, never a default: armed on connect, the deadline loses
+     * the race to the first byte on fast routes, which is how the earlier
+     * version of this measured 2 mid-stream cuts out of ~1500 on #94919.
+     */
+    abandonFrom: z.enum(["first-byte", "request"]).optional(),
   })
-  .strict();
+  .strict()
+  .refine((config) => config.abandonFrom === undefined || config.abandonAfterMs !== undefined, {
+    message: '"abandonFrom" configures nothing without "abandonAfterMs"',
+    path: ["abandonFrom"],
+  });
 
 export type RouteConfig = z.infer<typeof routeConfigSchema>;
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
 import path from "node:path";
+import type { AbandonOrigin } from "./abandon-load.js";
 import { attributeDiff, type AttributedDiff } from "./attribution.js";
 import {
   assessConfidence,
@@ -79,6 +80,13 @@ export type RouteReport =
       unreclaimedTrend: TrendResult;
       /** Requests each cycle served — what the growth rates normalize by. */
       requestsPerCycle: number;
+      /**
+       * The early-disconnect regime, when the route asked for one. Recorded
+       * because a curve measured with cuts landing mid-stream and one measured
+       * with cuts landing before the response are different experiments, and
+       * the counters alone do not say which was intended.
+       */
+      abandon?: { afterMs: number; from: AbandonOrigin };
       /**
        * Distinct keys the load cycled through, when the route asked for a
        * bounded set. A verdict about a cache depends on how many keys it saw,
@@ -412,6 +420,9 @@ async function measureRoute(
     ...(routeConfig.abandonAfterMs !== undefined && {
       abandonAfterMs: routeConfig.abandonAfterMs,
     }),
+    ...(routeConfig.abandonFrom !== undefined && {
+      abandonFrom: routeConfig.abandonFrom,
+    }),
   });
 
   // Audited before anything is derived from the verdict: a measurement that
@@ -429,6 +440,9 @@ async function measureRoute(
     warmupRequests: options.warmupRequests ?? RITUAL_DEFAULTS.warmupRequests,
     ...(routeConfig.abandonAfterMs !== undefined && {
       abandonAfterMs: routeConfig.abandonAfterMs,
+    }),
+    ...(routeConfig.abandonFrom !== undefined && {
+      abandonFrom: routeConfig.abandonFrom,
     }),
   });
   const verdict = confidence.supersededVerdict ?? result.trend.verdict;
@@ -466,6 +480,12 @@ async function measureRoute(
     unreclaimedSamples: result.unreclaimedSamples,
     unreclaimedTrend: result.unreclaimedTrend,
     requestsPerCycle: result.requestsPerCycle,
+    ...(routeConfig.abandonAfterMs !== undefined && {
+      abandon: {
+        afterMs: routeConfig.abandonAfterMs,
+        from: routeConfig.abandonFrom ?? "first-byte",
+      },
+    }),
     timings: result.timings,
     loadOutcomes: result.loadOutcomes,
     settleOutcomes: result.settleOutcomes,


### PR DESCRIPTION
## What

Lets a route choose when its abandon deadline starts: at the first byte of the
response, as today, or at the moment the request is written.

```json
{ "abandonAfterMs": 60, "abandonFrom": "request" }
```

The default does not move, and `abandonFrom` without `abandonAfterMs` is
rejected rather than ignored.

The audit follows the choice. Under the request origin a pre-response cut is
the experiment, not a shortfall, so `abandon-before-response` is no longer
raised for it. The check on how much was abandoned at all still applies to both
origins, because a run that cut nothing tested nothing either way.

`run.json` and the report now record which experiment ran:

```
cut 60ms after the request was sent, so the client is gone before the response starts
```

## Why

The first-byte deadline is right and it stays the default: an earlier version
armed the window on connect and lost the race to the first byte on fast routes,
landing 2 of ~1500 cuts per cycle mid-stream on the #94919 reproduction.

It also puts one class of leak out of reach — the ones that need the client
already gone before the server produces anything. That is what a closed tab or
a load-balancer timeout does to a slow route.

Measured against the public reproduction for
[vercel/next.js#84648](https://github.com/vercel/next.js/issues/84648), whose
upstream answers in 400 ms while its own load generator cuts at 60 ms:

| origin | abandoned | before the response |
|---|---|---|
| `first-byte` | 133–279 of 2000 per cycle | 0 |
| `request` | 45513 of 45513 across three runs | 45513 |

The old runs were not wrong, they were empty: every cut landed on requests
whose body took longer than 60 ms to stream, and the path the issue describes
was never touched. The audit said so on every cycle, which is how this was
found.

The anchor case was re-measured to show it did not move. The #89091
reproduction, `abandonAfterMs: 4` with gzip, unchanged config: 7974 of 8000
abandoned, 100% of them mid-stream, none pre-response, high confidence.

One knock-on worth naming: suppressing that warning means a request-origin run
can now report high confidence where it previously reported low. That is the
intended effect — the warning was describing the route's own design as a
defect — and it does change which runs produce an `ISSUE-<route>.md` draft.
Verdict semantics are untouched: `supersededVerdict` comes from
`isVerdictInvalid`, which this does not reach.

## Checklist

- [x] Tests cover the new behavior
- [x] `pnpm typecheck && pnpm test` pass locally
- [x] Verdict semantics untouched, or the mutation suite was run
