### PR TITLE
feat: say what a build's worker retains, not only that it retains

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,14 +367,18 @@ through the build's source maps.
   ([#97464](https://github.com/vercel/next.js/issues/97464)). It does not apply
   to projects using `experimental.workerThreads: true`: a worker thread has no
   resident memory of its own to sample, and the run says so instead of
-  reporting a number that would be measuring the parent. It also names *what*
-  the worker retained, from a snapshot pair taken by signalling the worker —
-  but only over a low slice of the curve, and it says which slice. A snapshot
-  is written to disk at roughly 0.4x to 0.8x the worker's resident size, so
-  past about a gigabyte of worker memory it exceeds the 512 MB a V8 string can
-  hold and cannot be read back. Both captures therefore happen below that, and
-  the report states what share of the observed growth they span (19% on the
-  #97464 reproduction, whose worker peaks near 4 GB).
+  reporting a number that would be measuring the parent.
+- **`next-leak build <dir> --attribute`** additionally names *what* the worker
+  retained, by signalling it for a pair of heap snapshots. **Opt-in, and slow
+  by nature:** the signal makes the worker write its whole heap to disk, which
+  on the #97464 reproduction has stalled a build for minutes at a time and
+  once for an hour and a half. Use it on a reproduction you are investigating,
+  not on a build you need to finish. It also covers only a low slice of the
+  curve, and says which: a snapshot weighs roughly 0.4x to 0.8x the worker's
+  resident size, so past about a gigabyte it exceeds the 512 MB a V8 string can
+  hold and cannot be read back — both captures happen below that, and the
+  report states what share of the observed growth they span (19% on that
+  reproduction, whose worker peaks near 4 GB).
 - **Architectures:** verified on **arm64 and x64** (linux/amd64 in Docker) — same app, same parameters, same verdicts.
 - **Attribution** (naming the file) needs a Turbopack build with server sourcemaps — the Next 15+ default. On webpack builds the registry is empty by design and findings degrade to `unattributed` with raw retainer chains; measurement itself does not depend on it. Note that `output: "standalone"` + `--webpack` produced a bundle that could not start at all on `16.3.0-canary.90` (missing `@swc/helpers`), independently of this tool.
 - Empirically validated on Next **15.5.4, 16.0.x, 16.1.5, 16.2.x, 16.3.0/16.3.1 and 16.3-canary** (incl. Sentry, OpenTelemetry, PPR and i18n apps), against the public reproductions attached to real issues (open and since-fixed). Most recent measurements, 2026-08-17/18: the runtime path on 16.2.12 and 16.3.1-canary.18, the build path on 16.2.12 and 16.3.1. The contracts it relies on are stable since Next 13–14, but older versions are untested.

--- a/README.md
+++ b/README.md
@@ -367,7 +367,14 @@ through the build's source maps.
   ([#97464](https://github.com/vercel/next.js/issues/97464)). It does not apply
   to projects using `experimental.workerThreads: true`: a worker thread has no
   resident memory of its own to sample, and the run says so instead of
-  reporting a number that would be measuring the parent.
+  reporting a number that would be measuring the parent. It also names *what*
+  the worker retained, from a snapshot pair taken by signalling the worker —
+  but only over a low slice of the curve, and it says which slice. A snapshot
+  is written to disk at roughly 0.4x to 0.8x the worker's resident size, so
+  past about a gigabyte of worker memory it exceeds the 512 MB a V8 string can
+  hold and cannot be read back. Both captures therefore happen below that, and
+  the report states what share of the observed growth they span (19% on the
+  #97464 reproduction, whose worker peaks near 4 GB).
 - **Architectures:** verified on **arm64 and x64** (linux/amd64 in Docker) — same app, same parameters, same verdicts.
 - **Attribution** (naming the file) needs a Turbopack build with server sourcemaps — the Next 15+ default. On webpack builds the registry is empty by design and findings degrade to `unattributed` with raw retainer chains; measurement itself does not depend on it. Note that `output: "standalone"` + `--webpack` produced a bundle that could not start at all on `16.3.0-canary.90` (missing `@swc/helpers`), independently of this tool.
 - Empirically validated on Next **15.5.4, 16.0.x, 16.1.5, 16.2.x, 16.3.0/16.3.1 and 16.3-canary** (incl. Sentry, OpenTelemetry, PPR and i18n apps), against the public reproductions attached to real issues (open and since-fixed). Most recent measurements, 2026-08-17/18: the runtime path on 16.2.12 and 16.3.1-canary.18, the build path on 16.2.12 and 16.3.1. The contracts it relies on are stable since Next 13–14, but older versions are untested.

--- a/src/build-attribution.test.ts
+++ b/src/build-attribution.test.ts
@@ -36,6 +36,7 @@ const capture: NonNullable<BuildRunResult["capture"]> = {
   files: { baselineFile: "/run/a.heapsnapshot", afterFile: "/run/b.heapsnapshot" },
   baselineRssBytes: 200 * MB,
   afterRssBytes: 1000 * MB,
+  peakRssBytes: 3400 * MB,
 };
 
 const deps = (overrides: Partial<BuildAttributionDeps> = {}): BuildAttributionDeps => ({
@@ -88,6 +89,20 @@ describe("attributeBuildCapture", () => {
 
     // 200 MB to 1000 MB out of a 3400 MB peak: a quarter of the growth.
     expect(result?.bracketed).toBeCloseTo(0.25, 2);
+  });
+
+  // On a multi-worker build the highest peak can belong to a worker nothing
+  // was captured from, and quoting the share against it would describe a curve
+  // these findings say nothing about.
+  it("quotes the share against the captured worker, not the loudest one", async () => {
+    const result = measured({ ...capture, peakRssBytes: 1000 * MB });
+    // Another worker of the same build reached far higher.
+    result.peakWorkerRssBytes = 9000 * MB;
+
+    const attribution = await attributeBuildCapture(result, "/apps/docs", () => {}, deps());
+
+    // 200 MB to 1000 MB of a worker that peaked at 1000 MB: all of its growth.
+    expect(attribution?.bracketed).toBe(1);
   });
 
   it("reads the registry from the finished build, never mid-flight", async () => {

--- a/src/build-attribution.test.ts
+++ b/src/build-attribution.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import { attributeBuildCapture, type BuildAttributionDeps } from "./build-attribution.js";
+import type { BuildRunResult } from "./build-run.js";
+import { SnapshotError, type HeapDiff } from "./heap-diff.js";
+
+const MB = 1024 * 1024;
+
+const emptyDiff: HeapDiff = {
+  grownNodes: [],
+  newNodes: [],
+  typeDeltas: [],
+};
+
+const measured = (capture: BuildRunResult["capture"]): BuildRunResult => ({
+  appDir: "/apps/docs",
+  status: "measured",
+  samplingFailure: null,
+  verdict: "leak",
+  trend: { verdict: "leak", growthPerCycle: 315 * MB, deltas: [], source: "heap" },
+  levels: [],
+  workers: [{ pid: 500, samples: [] }],
+  parentSamples: [],
+  peakWorkerRssBytes: 3400 * MB,
+  netGrowthBytes: 0,
+  pagesGenerated: null,
+  retentionPerPageBytes: null,
+  heapExhausted: true,
+  capture,
+  strippedCapWarning: null,
+  exitCode: 1,
+  output: "",
+});
+
+const capture: NonNullable<BuildRunResult["capture"]> = {
+  pid: 500,
+  files: { baselineFile: "/run/a.heapsnapshot", afterFile: "/run/b.heapsnapshot" },
+  baselineRssBytes: 200 * MB,
+  afterRssBytes: 1000 * MB,
+};
+
+const deps = (overrides: Partial<BuildAttributionDeps> = {}): BuildAttributionDeps => ({
+  diff: vi.fn(async () => emptyDiff),
+  registry: vi.fn(async () => new Map([[1, "app/page.tsx"]])),
+  ...overrides,
+});
+
+describe("attributeBuildCapture", () => {
+  it("returns nothing when the run captured no pair", async () => {
+    expect(await attributeBuildCapture(measured(null), "/apps/docs", () => {}, deps())).toBeNull();
+  });
+
+  // The verdict and curve stand on their own. An addition that can fail must
+  // not be able to take the report down with it.
+  it("degrades to nothing when the snapshot cannot be parsed", async () => {
+    const messages: string[] = [];
+    const result = await attributeBuildCapture(
+      measured(capture),
+      "/apps/docs",
+      (message) => messages.push(message),
+      deps({
+        diff: vi.fn(async () => {
+          throw new SnapshotError("heap snapshot is 2388 MB, past the 512 MB a string can hold");
+        }),
+      })
+    );
+
+    expect(result).toBeNull();
+    expect(messages.join("\n")).toContain("past the 512 MB");
+  });
+
+  it("degrades to nothing when the diff throws for any other reason", async () => {
+    const result = await attributeBuildCapture(
+      measured(capture),
+      "/apps/docs",
+      () => {},
+      deps({
+        diff: vi.fn(async () => {
+          throw new Error("boom");
+        }),
+      })
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("reports how much of the observed growth the pair spans", async () => {
+    const result = await attributeBuildCapture(measured(capture), "/apps/docs", () => {}, deps());
+
+    // 200 MB to 1000 MB out of a 3400 MB peak: a quarter of the growth.
+    expect(result?.bracketed).toBeCloseTo(0.25, 2);
+  });
+
+  it("reads the registry from the finished build, never mid-flight", async () => {
+    const registry = vi.fn(async () => new Map<number, string>());
+    await attributeBuildCapture(measured(capture), "/apps/docs", () => {}, deps({ registry }));
+
+    expect(registry).toHaveBeenCalledWith("/apps/docs/.next/server");
+  });
+
+  it("keeps going with an empty registry rather than guessing an owner", async () => {
+    const result = await attributeBuildCapture(
+      measured(capture),
+      "/apps/docs",
+      () => {},
+      deps({ registry: vi.fn(async () => new Map<number, string>()) })
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.registrySize).toBe(0);
+    expect(result?.attributed.route.owner).toBe("unattributed");
+  });
+});

--- a/src/build-attribution.ts
+++ b/src/build-attribution.ts
@@ -1,0 +1,80 @@
+import path from "node:path";
+import { attributeDiff, type AttributedDiff } from "./attribution.js";
+import type { BuildRunResult } from "./build-run.js";
+import { bracketedShare } from "./build-snapshot.js";
+import { diffSnapshotFiles, SnapshotError, type HeapDiff } from "./heap-diff.js";
+import { extractModuleRegistry } from "./module-registry.js";
+
+export type BuildAttribution = {
+  diff: HeapDiff;
+  attributed: AttributedDiff;
+  /** Modules the registry resolved. Zero means every finding stays unattributed. */
+  registrySize: number;
+  /** Share of the worker's observed growth the snapshot pair spans, 0 to 1. */
+  bracketed: number;
+  baselineRssBytes: number;
+  afterRssBytes: number;
+  /** Where the pair was stored, so the finding can be checked by hand. */
+  baselineFile: string;
+  afterFile: string;
+};
+
+export type BuildAttributionDeps = {
+  diff: typeof diffSnapshotFiles;
+  registry: typeof extractModuleRegistry;
+};
+
+const defaultDeps: BuildAttributionDeps = {
+  diff: diffSnapshotFiles,
+  registry: extractModuleRegistry,
+};
+
+/**
+ * Names what a build's worker retained, from the pair the run captured.
+ *
+ * Returns null rather than throwing on every failure path. A build measurement
+ * stands on its curve and its verdict; this is an addition to the report, and
+ * an addition that can fail must not be able to take the report with it.
+ *
+ * The registry is read from `.next/server` *after* the build, never during it:
+ * a half-written chunk can resolve a module id to the wrong source, and naming
+ * the wrong owner confidently is worse than naming none.
+ */
+export async function attributeBuildCapture(
+  result: BuildRunResult,
+  appDir: string,
+  onProgress: (message: string) => void = () => {},
+  deps: BuildAttributionDeps = defaultDeps
+): Promise<BuildAttribution | null> {
+  const capture = result.capture;
+  if (capture === null) {
+    return null;
+  }
+  onProgress(`diffing what worker ${capture.pid} retained`);
+  let diff: HeapDiff;
+  try {
+    diff = await deps.diff(capture.files.baselineFile, capture.files.afterFile);
+  } catch (cause) {
+    onProgress(
+      cause instanceof SnapshotError
+        ? `no attribution: ${cause.message}`
+        : `no attribution: the snapshot pair could not be diffed`
+    );
+    return null;
+  }
+  const registry = await deps.registry(path.join(appDir, ".next", "server"));
+  return {
+    diff,
+    attributed: attributeDiff(diff, registry),
+    registrySize: registry.size,
+    bracketed: bracketedShare(
+      capture.baselineRssBytes,
+      capture.afterRssBytes,
+      result.peakWorkerRssBytes
+    ),
+    baselineRssBytes: capture.baselineRssBytes,
+    afterRssBytes: capture.afterRssBytes,
+    baselineFile: capture.files.baselineFile,
+    afterFile: capture.files.afterFile,
+  };
+}

--- a/src/build-attribution.ts
+++ b/src/build-attribution.ts
@@ -67,10 +67,13 @@ export async function attributeBuildCapture(
     diff,
     attributed: attributeDiff(diff, registry),
     registrySize: registry.size,
+    // Against the captured worker's own peak. `result.peakWorkerRssBytes` is
+    // the highest of every worker, which on a multi-worker build can belong to
+    // a process these findings say nothing about.
     bracketed: bracketedShare(
       capture.baselineRssBytes,
       capture.afterRssBytes,
-      result.peakWorkerRssBytes
+      capture.peakRssBytes
     ),
     baselineRssBytes: capture.baselineRssBytes,
     afterRssBytes: capture.afterRssBytes,

--- a/src/build-report.test.ts
+++ b/src/build-report.test.ts
@@ -18,6 +18,7 @@ const baseResult: BuildRunResult = {
   pagesGenerated: 1700,
   retentionPerPageBytes: 0.97 * MB,
   heapExhausted: true,
+  capture: null,
   strippedCapWarning: null,
   exitCode: 1,
   output: "",
@@ -73,6 +74,7 @@ describe("formatBuildReport", () => {
       trend: null,
       levels: [],
       heapExhausted: false,
+  capture: null,
       output: "Type error: Property 'x' does not exist",
     });
 
@@ -149,5 +151,76 @@ describe("formatBuildReport when the table cannot be read", () => {
     expect(output).toContain("spawn ps EPERM");
     expect(output).toContain("not a clean run");
     expect(output).not.toContain("nothing to measure");
+  });
+});
+
+// The bracketed share is the load-bearing number here: the parse limit keeps
+// both snapshots low, so the findings explain a minority of the curve and the
+// report must not let a reader assume otherwise.
+describe("formatBuildReport attribution", () => {
+  const attribution = {
+    diff: {
+      grownNodes: [
+        {
+          name: "IncrementalCache",
+          retainedBytes: 180 * MB,
+          retainerChain: "Object[.cache] <- Module[.exports]",
+          moduleIds: [1],
+        },
+      ],
+      newNodes: [],
+      typeDeltas: [],
+    },
+    attributed: {
+      findings: [{ owner: "framework" as const, source: null, packageName: "next" }],
+      route: {
+        owner: "framework" as const,
+        source: null,
+        packageName: "next",
+        dominance: 1,
+      },
+    },
+    registrySize: 198,
+    bracketed: 0.25,
+    baselineRssBytes: 200 * MB,
+    afterRssBytes: 1000 * MB,
+    baselineFile: "/run/worker-500-baseline.heapsnapshot",
+    afterFile: "/run/worker-500-after.heapsnapshot",
+  };
+
+  it("says what was retained, and over how much of the curve", () => {
+    const output = formatBuildReport(baseResult, attribution as never);
+
+    expect(output).toContain("IncrementalCache");
+    expect(output).toContain("25% of the growth");
+    expect(output).toContain("200.0 MB");
+  });
+
+  it("says when no owner could be resolved instead of naming one", () => {
+    const output = formatBuildReport(
+      baseResult,
+      {
+        ...attribution,
+        registrySize: 0,
+        attributed: {
+          findings: [{ owner: "unattributed" as const, source: null, packageName: null }],
+          route: {
+            owner: "unattributed" as const,
+            source: null,
+            packageName: null,
+            dominance: 0,
+          },
+        },
+      } as never
+    );
+
+    expect(output).toContain("no module registry resolved");
+    expect(output).toContain("unattributed");
+  });
+
+  it("is silent when there is no attribution at all", () => {
+    const output = formatBuildReport(baseResult);
+
+    expect(output).not.toContain("what it retained");
   });
 });

--- a/src/build-report.ts
+++ b/src/build-report.ts
@@ -153,9 +153,8 @@ export function formatBuildReport(
     lines.push(`      ${result.workers.length} workers ran; the verdict is the worst of them`);
   }
 
-  lines.push(...attributionLines(attribution));
-
   lines.push(
+    ...attributionLines(attribution),
     "",
     `  peak worker rss ${mb(result.peakWorkerRssBytes)} · sampled from the process tree, so a`,
     `  spike shorter than the polling interval is not observed`

--- a/src/build-report.ts
+++ b/src/build-report.ts
@@ -1,3 +1,4 @@
+import type { BuildAttribution } from "./build-attribution.js";
 import type { BuildRunResult } from "./build-run.js";
 
 const MB = 1024 * 1024;
@@ -29,6 +30,55 @@ function growthLine(result: BuildRunResult): string {
   return `      grew ${mb(result.netGrowthBytes)} across the generation phase${perPage}`;
 }
 
+const MAX_REPORTED_FINDINGS = 3;
+
+/**
+ * Names what the worker retained between the two snapshots.
+ *
+ * The bracketed share leads, because it bounds everything below it. The parse
+ * limit forces both snapshots low on the curve — a snapshot past roughly a
+ * gigabyte of worker memory cannot be read back — so on a build that peaks at
+ * several gigabytes the pair explains a minority of the growth. Printing the
+ * findings without that number invites the reader to treat them as the whole
+ * story.
+ */
+function attributionLines(attribution: BuildAttribution | null): string[] {
+  if (attribution === null) {
+    return [];
+  }
+  const { diff, attributed, bracketed } = attribution;
+  const findings = [...diff.grownNodes, ...diff.newNodes];
+  if (findings.length === 0) {
+    return ["", `  nothing grew between the two snapshots`];
+  }
+  const lines = [
+    "",
+    `  what it retained, between ${mb(attribution.baselineRssBytes)} and ` +
+      `${mb(attribution.afterRssBytes)} of worker rss —`,
+    `  ${(bracketed * 100).toFixed(0)}% of the growth this run observed. The rest is not`,
+    `  attributed: a snapshot taken higher up cannot be parsed back.`,
+  ];
+  if (attribution.registrySize === 0) {
+    lines.push(
+      `      no module registry resolved, so no owner is named below — only`,
+      `      where the bytes hang`
+    );
+  }
+  lines.push(
+    `      snapshots: ${attribution.baselineFile} / ${attribution.afterFile}`
+  );
+  for (const [index, finding] of findings.slice(0, MAX_REPORTED_FINDINGS).entries()) {
+    const owner = attributed.findings[index];
+    const name = owner?.source ?? owner?.packageName ?? owner?.owner ?? "unattributed";
+    lines.push(
+      `      ↳ ${finding.name === "" ? "(anonymous)" : finding.name} ` +
+        `${mb(finding.retainedBytes)} · ${name}`,
+      `          ${finding.retainerChain}`
+    );
+  }
+  return lines;
+}
+
 /**
  * Renders the build report.
  *
@@ -38,7 +88,10 @@ function growthLine(result: BuildRunResult): string {
  * still the honest axis here — it is what a CI runner's limit is enforced
  * against and what the OOM killer reads.
  */
-export function formatBuildReport(result: BuildRunResult): string {
+export function formatBuildReport(
+  result: BuildRunResult,
+  attribution: BuildAttribution | null = null
+): string {
   const lines: string[] = [`next-leak build · ${result.appDir}`, ""];
 
   if (result.strippedCapWarning !== null) {
@@ -99,6 +152,8 @@ export function formatBuildReport(result: BuildRunResult): string {
   if (result.workers.length > 1) {
     lines.push(`      ${result.workers.length} workers ran; the verdict is the worst of them`);
   }
+
+  lines.push(...attributionLines(attribution));
 
   lines.push(
     "",

--- a/src/build-run.test.ts
+++ b/src/build-run.test.ts
@@ -53,6 +53,7 @@ function makeDeps(
     exitCode?: number | null;
     parentMb?: number[];
     noWorker?: boolean;
+    onSignal?: (pid: number) => void;
   } = {}
 ): BuildRunDeps {
   let poll = 0;
@@ -64,6 +65,7 @@ function makeDeps(
       child = fakeChild(options.output ?? "");
       return child as never;
     },
+    signalWorker: (pid) => options.onSignal?.(pid),
     sampleTable: async (): Promise<ProcessTableSample> => {
       if (poll >= workerMb.length) {
         setImmediate(() => child?.emit("exit", exitCode));
@@ -305,5 +307,63 @@ describe("per-page retention when the build crashed", () => {
     expect(result.pagesGenerated).toBe(1252);
     expect(result.peakWorkerRssBytes).toBe(2479 * MB);
     expect(result.retentionPerPageBytes).toBeNull();
+  });
+});
+
+// Capture is an addition to the report. Every one of these asserts that the
+// verdict and the curve survive a capture that did not work out.
+describe("runBuildMeasurement capture", () => {
+  it("does not signal at all when no work directory was given", async () => {
+    const signalled: number[] = [];
+    const result = await runBuildMeasurement(
+      { appDir: await makeProject() },
+      makeDeps([200, 400, 700], { onSignal: (pid) => signalled.push(pid) })
+    );
+
+    expect(signalled).toEqual([]);
+    expect(result.capture).toBeNull();
+    expect(result.status).toBe("measured");
+  });
+
+  it("still reports a verdict when the worker dies before the second snapshot", async () => {
+    const workDir = await mkdtemp(path.join(tmpdir(), "next-leak-capture-"));
+    const signalled: number[] = [];
+    const result = await runBuildMeasurement(
+      { appDir: await makeProject(), workDir },
+      makeDeps([200, 260], {
+        output: "JavaScript heap out of memory",
+        exitCode: 1,
+        onSignal: (pid) => signalled.push(pid),
+      })
+    );
+
+    // The baseline was taken and the worker never grew enough for a second.
+    expect(signalled).toEqual([WORKER_PID]);
+    expect(result.capture).toBeNull();
+    expect(result.verdict).toBe("leak");
+    expect(result.heapExhausted).toBe(true);
+  });
+
+  it("signals twice once the worker reaches the capture target", async () => {
+    const workDir = await mkdtemp(path.join(tmpdir(), "next-leak-capture-"));
+    const signalled: number[] = [];
+    await runBuildMeasurement(
+      { appDir: await makeProject(), workDir },
+      makeDeps([200, 400, 1000], { onSignal: (pid) => signalled.push(pid) })
+    );
+
+    expect(signalled).toEqual([WORKER_PID, WORKER_PID]);
+  });
+
+  it("never signals a worker already past the parse limit", async () => {
+    const workDir = await mkdtemp(path.join(tmpdir(), "next-leak-capture-"));
+    const signalled: number[] = [];
+    await runBuildMeasurement(
+      { appDir: await makeProject(), workDir },
+      makeDeps([2000, 2600, 3000], { onSignal: (pid) => signalled.push(pid) })
+    );
+
+    // A snapshot up there is written, costs the disk, and cannot be read back.
+    expect(signalled).toEqual([]);
   });
 });

--- a/src/build-run.test.ts
+++ b/src/build-run.test.ts
@@ -54,6 +54,8 @@ function makeDeps(
     parentMb?: number[];
     noWorker?: boolean;
     onSignal?: (pid: number) => void;
+    /** From this poll on, the worker pid is reported outside the build tree. */
+    detachAfterPoll?: number;
   } = {}
 ): BuildRunDeps {
   let poll = 0;
@@ -75,12 +77,17 @@ function makeDeps(
       const parentRss = options.parentMb?.[Math.min(poll, (options.parentMb?.length ?? 1) - 1)] ?? 300;
       poll += 1;
       const parentRow = `${BUILD_PID} 1 ${parentRss * 1024} next-build\n`;
+      // Pids get recycled: past `detachAfterPoll` the same number belongs to
+      // something that is not the build's child any more.
+      const detached =
+        options.detachAfterPoll !== undefined && poll > options.detachAfterPoll;
+      const workerRow = detached
+        ? `${WORKER_PID} 1 ${workerRss * 1024} /usr/bin/unrelated\n`
+        : `${WORKER_PID} ${BUILD_PID} ${workerRss * 1024} ${WORKER_COMMAND}\n`;
       return {
         ok: true,
         rows: parseProcessTable(
-          options.noWorker === true
-            ? parentRow
-            : `${parentRow}${WORKER_PID} ${BUILD_PID} ${workerRss * 1024} ${WORKER_COMMAND}\n`
+          options.noWorker === true ? parentRow : `${parentRow}${workerRow}`
         ),
       };
     },
@@ -353,6 +360,24 @@ describe("runBuildMeasurement capture", () => {
     );
 
     expect(signalled).toEqual([WORKER_PID, WORKER_PID]);
+  });
+
+  // A remembered pid looked up across the whole process table would follow a
+  // stranger, and this code signals what it finds — SIGUSR2 with no handler
+  // kills a process.
+  it("stops following a pid once it leaves the build tree", async () => {
+    const workDir = await mkdtemp(path.join(tmpdir(), "next-leak-capture-"));
+    const signalled: number[] = [];
+    await runBuildMeasurement(
+      { appDir: await makeProject(), workDir },
+      makeDeps([200, 1000, 1000], {
+        detachAfterPoll: 1,
+        onSignal: (pid) => signalled.push(pid),
+      })
+    );
+
+    // Only the baseline, taken while the pid really was the build's worker.
+    expect(signalled).toEqual([WORKER_PID]);
   });
 
   it("never signals a worker already past the parse limit", async () => {

--- a/src/build-run.ts
+++ b/src/build-run.ts
@@ -271,6 +271,41 @@ export async function runBuildMeasurement(
   let captureStage: CaptureStage = "waiting";
   let captureBaselineRss: number | null = null;
   let captureAfterRss: number | null = null;
+  /**
+   * Advances the capture state machine for one poll.
+   *
+   * Split out of the polling loop because the loop's job is sampling: capture
+   * is a passenger on it, and reading them interleaved hid which `continue`
+   * belonged to which concern.
+   */
+  const stepCapture = (rows: readonly ProcessRow[], rootPid: number): void => {
+    const followed: ProcessRow | undefined =
+      capturePid === null
+        ? descendantsOf(rows, rootPid).find(isStaticGenWorker)
+        : rows.find((row) => row.pid === capturePid);
+    if (followed === undefined) {
+      return;
+    }
+    capturePid ??= followed.pid;
+    switch (decideCapture(followed.rssBytes, captureStage, captureBaselineRss)) {
+      case "take-baseline":
+        deps.signalWorker(followed.pid);
+        captureStage = "baseline-taken";
+        captureBaselineRss = followed.rssBytes;
+        return;
+      case "take-after":
+        deps.signalWorker(followed.pid);
+        captureStage = "pair-taken";
+        captureAfterRss = followed.rssBytes;
+        return;
+      case "give-up":
+        captureStage = "missed";
+        return;
+      case "wait":
+        return;
+    }
+  };
+
   const polling = (async (): Promise<void> => {
     while (!finished) {
       await deps.sleep(POLL_MS);
@@ -285,33 +320,8 @@ export async function runBuildMeasurement(
         return;
       }
       recordSample(sample.rows, child.pid, deps.now() - startedAt, workerSamples, parentSamples);
-      if (!capturing) {
-        continue;
-      }
-      // Annotated because `capturePid` is assigned from this value below, which
-      // makes the inferred type circular.
-      const followed: ProcessRow | undefined =
-        capturePid === null
-          ? descendantsOf(sample.rows, child.pid).find(isStaticGenWorker)
-          : sample.rows.find((row) => row.pid === capturePid);
-      if (followed === undefined) {
-        continue;
-      }
-      capturePid ??= followed.pid;
-      if (followed.pid !== capturePid) {
-        continue;
-      }
-      const decision = decideCapture(followed.rssBytes, captureStage, captureBaselineRss);
-      if (decision === "take-baseline") {
-        deps.signalWorker(followed.pid);
-        captureStage = "baseline-taken";
-        captureBaselineRss = followed.rssBytes;
-      } else if (decision === "take-after") {
-        deps.signalWorker(followed.pid);
-        captureStage = "pair-taken";
-        captureAfterRss = followed.rssBytes;
-      } else if (decision === "give-up") {
-        captureStage = "missed";
+      if (capturing) {
+        stepCapture(sample.rows, child.pid);
       }
     }
   })();

--- a/src/build-run.ts
+++ b/src/build-run.ts
@@ -1,9 +1,11 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import {
+  clearPendingCapture,
   collectSnapshotPair,
   decideCapture,
   discardSnapshots,
+  registerPendingCapture,
   type CaptureStage,
   type CollectedPair,
 } from "./build-snapshot.js";
@@ -40,6 +42,13 @@ export type BuildCapture = {
   files: CollectedPair;
   baselineRssBytes: number;
   afterRssBytes: number;
+  /**
+   * Peak resident memory of *this* worker, not of the build. The share of
+   * growth the pair covers is quoted against the curve the findings came
+   * from, and on a multi-worker build the highest peak can belong to a worker
+   * nothing was captured from.
+   */
+  peakRssBytes: number;
 };
 
 export type BuildRunResult = {
@@ -163,6 +172,7 @@ type CollectOptions = {
   stage: CaptureStage;
   baselineRssBytes: number | null;
   afterRssBytes: number | null;
+  peakRssBytes: number;
 };
 
 /**
@@ -184,7 +194,7 @@ async function collectCapture(options: CollectOptions): Promise<BuildCapture | n
     await discardSnapshots(appDir, pid);
     return null;
   }
-  return { pid, files, baselineRssBytes, afterRssBytes };
+  return { pid, files, baselineRssBytes, afterRssBytes, peakRssBytes: options.peakRssBytes };
 }
 
 /** The worker that grew the most: a verdict from the average would hide it. */
@@ -279,10 +289,16 @@ export async function runBuildMeasurement(
    * belonged to which concern.
    */
   const stepCapture = (rows: readonly ProcessRow[], rootPid: number): void => {
+    // Both lookups are scoped to the build's own tree. Searching the whole
+    // table for a remembered pid would follow it off the end of the worker's
+    // life: pids get recycled, and this function signals what it finds, so a
+    // stranger inheriting the number would take a SIGUSR2 it has no handler
+    // for — which on POSIX kills it.
+    const descendants = descendantsOf(rows, rootPid);
     const followed: ProcessRow | undefined =
       capturePid === null
-        ? descendantsOf(rows, rootPid).find(isStaticGenWorker)
-        : rows.find((row) => row.pid === capturePid);
+        ? descendants.find(isStaticGenWorker)
+        : descendants.find((row) => row.pid === capturePid);
     if (followed === undefined) {
       return;
     }
@@ -292,6 +308,9 @@ export async function runBuildMeasurement(
         deps.signalWorker(followed.pid);
         captureStage = "baseline-taken";
         captureBaselineRss = followed.rssBytes;
+        // From here on there is a file in the project that only this run knows
+        // about, so an interrupt has to be able to find it.
+        registerPendingCapture(target.appDir, followed.pid);
         return;
       case "take-after":
         deps.signalWorker(followed.pid);
@@ -333,6 +352,7 @@ export async function runBuildMeasurement(
 
   const workers: WorkerSeries[] = [...workerSamples].map(([pid, samples]) => ({ pid, samples }));
   const heapExhausted = diedOfHeapExhaustion(output);
+  const capturedSamples = capturePid === null ? undefined : workerSamples.get(capturePid);
   const workerCapture = await collectCapture({
     appDir: target.appDir,
     workDir: options.workDir,
@@ -340,7 +360,11 @@ export async function runBuildMeasurement(
     stage: captureStage,
     baselineRssBytes: captureBaselineRss,
     afterRssBytes: captureAfterRss,
+    peakRssBytes: capturedSamples === undefined ? 0 : peakOf(capturedSamples),
   });
+  // Either the pair moved into the run directory or it was discarded; nothing
+  // is left in the project for an interrupt to sweep.
+  clearPendingCapture();
   const pagesGenerated = pagesGeneratedFrom(output);
 
   if (workers.length === 0) {

--- a/src/build-run.ts
+++ b/src/build-run.ts
@@ -1,5 +1,12 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
+import {
+  collectSnapshotPair,
+  decideCapture,
+  discardSnapshots,
+  type CaptureStage,
+  type CollectedPair,
+} from "./build-snapshot.js";
 import { validateBuildTarget } from "./build-target.js";
 import {
   classifyBuildSamples,
@@ -28,6 +35,13 @@ export type WorkerSeries = {
   samples: BuildSample[];
 };
 
+export type BuildCapture = {
+  pid: number;
+  files: CollectedPair;
+  baselineRssBytes: number;
+  afterRssBytes: number;
+};
+
 export type BuildRunResult = {
   appDir: string;
   /**
@@ -53,6 +67,12 @@ export type BuildRunResult = {
   retentionPerPageBytes: number | null;
   /** True when a worker hit the V8 heap limit — the finding, not a failure. */
   heapExhausted: boolean;
+  /**
+   * The snapshot pair captured from a worker, when one was. Attribution is an
+   * addition to this report, never a precondition for it: every field above is
+   * produced whether or not capture worked.
+   */
+  capture: BuildCapture | null;
   strippedCapWarning: string | null;
   exitCode: number | null;
   output: string;
@@ -60,6 +80,8 @@ export type BuildRunResult = {
 
 export type BuildRunOptions = {
   appDir: string;
+  /** Where a captured snapshot pair is moved to. Capture is skipped without it. */
+  workDir?: string;
   signal?: AbortSignal;
   onProgress?: (message: string) => void;
   /** Overrides `process.env` for the build. */
@@ -68,6 +90,7 @@ export type BuildRunOptions = {
 
 export type BuildRunDeps = {
   spawnBuild: (appDir: string, env: NodeJS.ProcessEnv) => ChildProcess;
+  signalWorker: (pid: number) => void;
   sampleTable: () => Promise<ProcessTableSample>;
   now: () => number;
   sleep: (ms: number) => Promise<void>;
@@ -89,8 +112,23 @@ function spawnNextBuild(appDir: string, env: NodeJS.ProcessEnv): ChildProcess {
   });
 }
 
+/**
+ * SIGUSR2 is what `--heapsnapshot-signal` listens for. Verified on a live
+ * static-generation worker: signalled at 73% of its heap cap it still finished
+ * the build, so this does not have to be done timidly.
+ */
+const signalWorker = (pid: number): void => {
+  try {
+    process.kill(pid, "SIGUSR2");
+  } catch {
+    // The worker finished between the poll and the signal. Not a failure:
+    // capture is optional and the run says so when no pair arrives.
+  }
+};
+
 const defaultDeps: BuildRunDeps = {
   spawnBuild: spawnNextBuild,
+  signalWorker,
   sampleTable: sampleProcessTable,
   now: () => Date.now(),
   sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
@@ -116,6 +154,37 @@ function recordSample(
     series.push({ atMs, rssBytes: row.rssBytes });
     workers.set(row.pid, series);
   }
+}
+
+type CollectOptions = {
+  appDir: string;
+  workDir: string | undefined;
+  pid: number | null;
+  stage: CaptureStage;
+  baselineRssBytes: number | null;
+  afterRssBytes: number | null;
+};
+
+/**
+ * Turns a finished capture into a usable pair, or cleans up after one that did
+ * not finish. A half-captured worker leaves a snapshot behind in the user's
+ * project, and nothing in the report would ever refer to it.
+ */
+async function collectCapture(options: CollectOptions): Promise<BuildCapture | null> {
+  const { appDir, workDir, pid, stage, baselineRssBytes, afterRssBytes } = options;
+  if (workDir === undefined || pid === null) {
+    return null;
+  }
+  if (stage !== "pair-taken" || baselineRssBytes === null || afterRssBytes === null) {
+    await discardSnapshots(appDir, pid);
+    return null;
+  }
+  const files = await collectSnapshotPair(appDir, workDir, pid);
+  if (files === null) {
+    await discardSnapshots(appDir, pid);
+    return null;
+  }
+  return { pid, files, baselineRssBytes, afterRssBytes };
 }
 
 /** The worker that grew the most: a verdict from the average would hide it. */
@@ -154,8 +223,20 @@ export async function runBuildMeasurement(
     progress(strippedCapWarning);
   }
 
+  // The worker inherits NODE_OPTIONS, which is how the signal handler gets
+  // installed without touching the build. Appending rather than replacing:
+  // a user's own NODE_OPTIONS carries their heap cap, and dropping it would
+  // silently change what is being measured.
+  const capturing = options.workDir !== undefined;
+  const buildEnv = capturing
+    ? {
+        ...env,
+        NODE_OPTIONS: `${env["NODE_OPTIONS"] ?? ""} --heapsnapshot-signal=SIGUSR2`.trim(),
+      }
+    : env;
+
   progress(`building ${target.appDir}`);
-  const child = deps.spawnBuild(target.appDir, env);
+  const child = deps.spawnBuild(target.appDir, buildEnv);
   registerChild(child);
 
   let output = "";
@@ -182,6 +263,14 @@ export async function runBuildMeasurement(
   options.signal?.addEventListener("abort", abort, { once: true });
 
   let samplingFailure: string | null = null;
+  // Capture follows one worker. Signalling every worker of a nine-worker build
+  // would write gigabytes for readings that say the same thing, so the first
+  // one seen is followed and its pid is reported, and attribution is withheld
+  // when the worker that ends up judged is a different one.
+  let capturePid: number | null = null;
+  let captureStage: CaptureStage = "waiting";
+  let captureBaselineRss: number | null = null;
+  let captureAfterRss: number | null = null;
   const polling = (async (): Promise<void> => {
     while (!finished) {
       await deps.sleep(POLL_MS);
@@ -196,6 +285,34 @@ export async function runBuildMeasurement(
         return;
       }
       recordSample(sample.rows, child.pid, deps.now() - startedAt, workerSamples, parentSamples);
+      if (!capturing) {
+        continue;
+      }
+      // Annotated because `capturePid` is assigned from this value below, which
+      // makes the inferred type circular.
+      const followed: ProcessRow | undefined =
+        capturePid === null
+          ? descendantsOf(sample.rows, child.pid).find(isStaticGenWorker)
+          : sample.rows.find((row) => row.pid === capturePid);
+      if (followed === undefined) {
+        continue;
+      }
+      capturePid ??= followed.pid;
+      if (followed.pid !== capturePid) {
+        continue;
+      }
+      const decision = decideCapture(followed.rssBytes, captureStage, captureBaselineRss);
+      if (decision === "take-baseline") {
+        deps.signalWorker(followed.pid);
+        captureStage = "baseline-taken";
+        captureBaselineRss = followed.rssBytes;
+      } else if (decision === "take-after") {
+        deps.signalWorker(followed.pid);
+        captureStage = "pair-taken";
+        captureAfterRss = followed.rssBytes;
+      } else if (decision === "give-up") {
+        captureStage = "missed";
+      }
     }
   })();
 
@@ -206,6 +323,14 @@ export async function runBuildMeasurement(
 
   const workers: WorkerSeries[] = [...workerSamples].map(([pid, samples]) => ({ pid, samples }));
   const heapExhausted = diedOfHeapExhaustion(output);
+  const workerCapture = await collectCapture({
+    appDir: target.appDir,
+    workDir: options.workDir,
+    pid: capturePid,
+    stage: captureStage,
+    baselineRssBytes: captureBaselineRss,
+    afterRssBytes: captureAfterRss,
+  });
   const pagesGenerated = pagesGeneratedFrom(output);
 
   if (workers.length === 0) {
@@ -230,6 +355,7 @@ export async function runBuildMeasurement(
       pagesGenerated,
       retentionPerPageBytes: null,
       heapExhausted,
+      capture: workerCapture,
       strippedCapWarning,
       exitCode,
       output,
@@ -278,6 +404,9 @@ export async function runBuildMeasurement(
         ? growthBytes / pagesGenerated
         : null,
     heapExhausted,
+    // A pair belonging to a worker other than the one judged supports no claim
+    // about the verdict above, so it is dropped rather than reported next to it.
+    capture: workerCapture !== null && workerCapture.pid === worst?.pid ? workerCapture : null,
     strippedCapWarning,
     exitCode,
     output,

--- a/src/build-snapshot.test.ts
+++ b/src/build-snapshot.test.ts
@@ -1,0 +1,147 @@
+import { mkdtemp, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  bracketedShare,
+  collectSnapshotPair,
+  decideCapture,
+  discardSnapshots,
+  snapshotsWrittenBy,
+  PARSEABLE_WORKER_RSS_BYTES,
+} from "./build-snapshot.js";
+
+const MB = 1024 * 1024;
+
+const tempDir = (): Promise<string> => mkdtemp(path.join(tmpdir(), "next-leak-snap-"));
+
+// The capture window is not a preference, it is what the parse limit leaves:
+// measured on the #97464 repro, a worker past ~1 GB writes a snapshot bigger
+// than a V8 string can hold, so both captures have to happen below it.
+describe("decideCapture", () => {
+  it("waits until the worker has loaded its own module graph", () => {
+    expect(decideCapture(40 * MB, "waiting", null)).toBe("wait");
+    expect(decideCapture(200 * MB, "waiting", null)).toBe("take-baseline");
+  });
+
+  it("gives up on a worker first seen above the parse limit", () => {
+    expect(decideCapture(PARSEABLE_WORKER_RSS_BYTES + 1, "waiting", null)).toBe("give-up");
+  });
+
+  // The second capture aims as late as the parse limit allows. Firing it at
+  // the growth floor instead put both snapshots below the worker's first
+  // sampled level on the #97464 repro, and the diff reported the worker
+  // booting rather than generating pages.
+  it("waits for the target rather than firing at the growth floor", () => {
+    expect(decideCapture(340 * MB, "baseline-taken", 200 * MB)).toBe("wait");
+    expect(decideCapture(PARSEABLE_WORKER_RSS_BYTES, "baseline-taken", 200 * MB)).toBe(
+      "take-after"
+    );
+  });
+
+  it("does not fire at the target when the pair would span too little", () => {
+    const nearLimit = PARSEABLE_WORKER_RSS_BYTES - 1;
+    expect(decideCapture(nearLimit, "baseline-taken", nearLimit - 1 * MB)).toBe("wait");
+  });
+
+  it("still takes the second when the worker jumped past the limit", () => {
+    // Better a snapshot at the edge than no pair at all: the alternative is a
+    // build that grew 900 MB between two polls and reports nothing.
+    expect(decideCapture(PARSEABLE_WORKER_RSS_BYTES + 1, "baseline-taken", 200 * MB)).toBe(
+      "take-after"
+    );
+  });
+
+  it("gives up when the worker passed the limit without growing enough", () => {
+    expect(
+      decideCapture(PARSEABLE_WORKER_RSS_BYTES + 1, "baseline-taken", PARSEABLE_WORKER_RSS_BYTES)
+    ).toBe("give-up");
+  });
+
+  it("does nothing more once the pair is taken", () => {
+    expect(decideCapture(3000 * MB, "pair-taken", 200 * MB)).toBe("wait");
+    expect(decideCapture(3000 * MB, "missed", null)).toBe("wait");
+  });
+});
+
+// V8 names the file after the pid, which is the only thing keeping two workers
+// of the same build from overwriting each other.
+describe("snapshotsWrittenBy", () => {
+  const names = [
+    "Heap.20260819.013329.17770.0.001.heapsnapshot",
+    "Heap.20260819.013512.17770.0.002.heapsnapshot",
+    "Heap.20260819.013400.99999.0.001.heapsnapshot",
+    "notes.md",
+  ];
+
+  it("matches only the given worker, in capture order", () => {
+    expect(snapshotsWrittenBy(17770, names)).toEqual([
+      "Heap.20260819.013329.17770.0.001.heapsnapshot",
+      "Heap.20260819.013512.17770.0.002.heapsnapshot",
+    ]);
+  });
+
+  it("does not confuse one worker for another", () => {
+    expect(snapshotsWrittenBy(99999, names)).toEqual([
+      "Heap.20260819.013400.99999.0.001.heapsnapshot",
+    ]);
+    expect(snapshotsWrittenBy(1234, names)).toEqual([]);
+  });
+});
+
+describe("collectSnapshotPair", () => {
+  it("moves both files out of the project", async () => {
+    const appDir = await tempDir();
+    const outDir = await tempDir();
+    await writeFile(path.join(appDir, "Heap.20260819.013329.500.0.001.heapsnapshot"), "a");
+    await writeFile(path.join(appDir, "Heap.20260819.013512.500.0.002.heapsnapshot"), "b");
+
+    const pair = await collectSnapshotPair(appDir, outDir, 500);
+
+    expect(pair).not.toBeNull();
+    expect(path.basename(pair?.baselineFile ?? "")).toBe("worker-500-baseline.heapsnapshot");
+    // Nothing of ours is left behind in the user's source tree.
+    expect((await readdir(appDir)).filter((n) => n.endsWith(".heapsnapshot"))).toEqual([]);
+    expect((await readdir(outDir)).sort()).toEqual([
+      "worker-500-after.heapsnapshot",
+      "worker-500-baseline.heapsnapshot",
+    ]);
+  });
+
+  it("returns null when only one snapshot ever landed", async () => {
+    const appDir = await tempDir();
+    const outDir = await tempDir();
+    await writeFile(path.join(appDir, "Heap.20260819.013329.500.0.001.heapsnapshot"), "a");
+
+    expect(await collectSnapshotPair(appDir, outDir, 500)).toBeNull();
+  });
+});
+
+describe("discardSnapshots", () => {
+  it("removes what a failed capture left in the project", async () => {
+    const appDir = await tempDir();
+    await writeFile(path.join(appDir, "Heap.20260819.013329.500.0.001.heapsnapshot"), "a");
+    await writeFile(path.join(appDir, "keep.txt"), "keep");
+
+    await discardSnapshots(appDir, 500);
+
+    expect((await readdir(appDir)).sort()).toEqual(["keep.txt"]);
+  });
+});
+
+// The share is what stops a reader treating the attributed bytes as the whole
+// curve, so it has to be honest at both ends.
+describe("bracketedShare", () => {
+  it("reports the fraction of observed growth the pair spans", () => {
+    expect(bracketedShare(200 * MB, 1000 * MB, 3400 * MB)).toBeCloseTo(0.25, 2);
+  });
+
+  it("never exceeds one or falls below zero", () => {
+    expect(bracketedShare(200 * MB, 3400 * MB, 3400 * MB)).toBe(1);
+    expect(bracketedShare(200 * MB, 100 * MB, 3400 * MB)).toBe(0);
+  });
+
+  it("treats a flat worker as fully bracketed rather than dividing by zero", () => {
+    expect(bracketedShare(200 * MB, 200 * MB, 200 * MB)).toBe(1);
+  });
+});

--- a/src/build-snapshot.test.ts
+++ b/src/build-snapshot.test.ts
@@ -1,12 +1,15 @@
-import { mkdtemp, readdir, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   bracketedShare,
+  clearPendingCapture,
   collectSnapshotPair,
   decideCapture,
+  discardPendingSnapshotsSync,
   discardSnapshots,
+  registerPendingCapture,
   snapshotsWrittenBy,
   PARSEABLE_WORKER_RSS_BYTES,
 } from "./build-snapshot.js";
@@ -44,15 +47,13 @@ describe("decideCapture", () => {
     expect(decideCapture(nearLimit, "baseline-taken", nearLimit - 1 * MB)).toBe("wait");
   });
 
-  it("still takes the second when the worker jumped past the limit", () => {
-    // Better a snapshot at the edge than no pair at all: the alternative is a
-    // build that grew 900 MB between two polls and reports nothing.
+  // Taking it anyway produced a 1.49 GB file on the #97464 repro and stalled
+  // the build for ninety minutes writing it. Past the limit there is nothing
+  // worth capturing, however much the pair would have spanned.
+  it("gives up rather than capture past the parse limit", () => {
     expect(decideCapture(PARSEABLE_WORKER_RSS_BYTES + 1, "baseline-taken", 200 * MB)).toBe(
-      "take-after"
+      "give-up"
     );
-  });
-
-  it("gives up when the worker passed the limit without growing enough", () => {
     expect(
       decideCapture(PARSEABLE_WORKER_RSS_BYTES + 1, "baseline-taken", PARSEABLE_WORKER_RSS_BYTES)
     ).toBe("give-up");
@@ -108,6 +109,23 @@ describe("collectSnapshotPair", () => {
     ]);
   });
 
+  // The first rename can succeed and the second fail. Whatever moved is then
+  // outside the directory `discardSnapshots` sweeps, so this is the only
+  // chance to take it back.
+  it("takes back a half-moved pair when the second move fails", async () => {
+    const appDir = await tempDir();
+    const outDir = await tempDir();
+    await writeFile(path.join(appDir, "Heap.20260819.013329.500.0.001.heapsnapshot"), "a");
+    await writeFile(path.join(appDir, "Heap.20260819.013512.500.0.002.heapsnapshot"), "b");
+    // A directory where the second file should go makes that rename fail while
+    // the first has already happened.
+    await mkdir(path.join(outDir, "worker-500-after.heapsnapshot"), { recursive: true });
+
+    expect(await collectSnapshotPair(appDir, outDir, 500)).toBeNull();
+
+    expect((await readdir(outDir)).filter((n) => n.endsWith("baseline.heapsnapshot"))).toEqual([]);
+  });
+
   it("returns null when only one snapshot ever landed", async () => {
     const appDir = await tempDir();
     const outDir = await tempDir();
@@ -143,5 +161,41 @@ describe("bracketedShare", () => {
 
   it("treats a flat worker as fully bracketed rather than dividing by zero", () => {
     expect(bracketedShare(200 * MB, 200 * MB, 200 * MB)).toBe(1);
+  });
+});
+
+// A second Ctrl+C exits the process outright, skipping every await that would
+// have removed these files.
+describe("discardPendingSnapshotsSync", () => {
+  it("sweeps the registered worker's snapshots and nothing else", async () => {
+    const appDir = await tempDir();
+    await writeFile(path.join(appDir, "Heap.20260819.013329.500.0.001.heapsnapshot"), "a");
+    await writeFile(path.join(appDir, "Heap.20260819.013400.999.0.001.heapsnapshot"), "b");
+    await writeFile(path.join(appDir, "keep.txt"), "keep");
+    registerPendingCapture(appDir, 500);
+
+    discardPendingSnapshotsSync();
+
+    expect((await readdir(appDir)).sort()).toEqual([
+      "Heap.20260819.013400.999.0.001.heapsnapshot",
+      "keep.txt",
+    ]);
+  });
+
+  it("does nothing when the capture already finished", async () => {
+    const appDir = await tempDir();
+    await writeFile(path.join(appDir, "Heap.20260819.013329.500.0.001.heapsnapshot"), "a");
+    registerPendingCapture(appDir, 500);
+    clearPendingCapture();
+
+    discardPendingSnapshotsSync();
+
+    expect((await readdir(appDir)).length).toBe(1);
+  });
+
+  it("survives a directory it cannot read", () => {
+    registerPendingCapture("/definitely/not/a/directory", 500);
+
+    expect(() => discardPendingSnapshotsSync()).not.toThrow();
   });
 });

--- a/src/build-snapshot.ts
+++ b/src/build-snapshot.ts
@@ -1,4 +1,5 @@
-import { readdir, rename } from "node:fs/promises";
+import { readdirSync, unlinkSync } from "node:fs";
+import { readdir, rename, unlink } from "node:fs/promises";
 import path from "node:path";
 
 /**
@@ -70,10 +71,14 @@ export function decideCapture(
   }
   const grown = rssBytes - (baselineRssBytes ?? 0);
   if (rssBytes > PARSEABLE_WORKER_RSS_BYTES) {
-    // Last chance: the worker jumped from below the target to past the limit
-    // between two polls. A snapshot at the edge beats no pair at all, provided
-    // the pair spans enough to be about the workload rather than start-up.
-    return grown >= MIN_PAIR_GROWTH_BYTES ? "take-after" : "give-up";
+    // No last chance here, deliberately. An earlier version took the snapshot
+    // anyway when the worker jumped past the limit between two polls, on the
+    // grounds that a pair at the edge beats no pair. Measured against the
+    // #97464 reproduction, that produced a 1.49 GB file — unparseable, as the
+    // limit says — and writing it stalled the build for ninety minutes with
+    // the worker frozen mid-render. A missing attribution costs the report one
+    // section; this costs the measurement.
+    return "give-up";
   }
   if (rssBytes < AFTER_TARGET_RSS_BYTES) {
     return "wait";
@@ -146,6 +151,11 @@ export async function collectSnapshotPair(
     await rename(path.join(appDir, baseline), baselineFile);
     await rename(path.join(appDir, after), afterFile);
   } catch {
+    // The first rename may have succeeded. Whatever it moved is now outside
+    // the directory `discardSnapshots` sweeps, so this is the only chance to
+    // take it back before it becomes half a gigabyte nothing refers to.
+    await unlink(baselineFile).catch(() => {});
+    await unlink(afterFile).catch(() => {});
     return null;
   }
   return { baselineFile, afterFile };
@@ -163,7 +173,6 @@ export async function discardSnapshots(appDir: string, pid: number): Promise<voi
   } catch {
     return;
   }
-  const { unlink } = await import("node:fs/promises");
   for (const name of snapshotsWrittenBy(pid, entries)) {
     try {
       await unlink(path.join(appDir, name));
@@ -192,4 +201,43 @@ export function bracketedShare(
     return 1;
   }
   return Math.min(1, Math.max(0, (afterRssBytes - baselineRssBytes) / total));
+}
+
+/**
+ * The capture in flight, if any, so an interrupt can clean up after it.
+ *
+ * A second Ctrl+C exits the process outright — deliberately, for the case
+ * where teardown itself is stuck — which skips every `await` that would have
+ * removed these files. Before this command wrote anything to the project that
+ * cost nothing; now it can strand hundreds of megabytes in a user's source
+ * tree, so the hard exit gets a synchronous sweep of its own.
+ */
+let pendingCapture: { appDir: string; pid: number } | null = null;
+
+export function registerPendingCapture(appDir: string, pid: number): void {
+  pendingCapture = { appDir, pid };
+}
+
+export function clearPendingCapture(): void {
+  pendingCapture = null;
+}
+
+/** Best effort, synchronous, and never throws: it runs on the way out. */
+export function discardPendingSnapshotsSync(): void {
+  if (pendingCapture === null) {
+    return;
+  }
+  const { appDir, pid } = pendingCapture;
+  pendingCapture = null;
+  try {
+    for (const name of snapshotsWrittenBy(pid, readdirSync(appDir))) {
+      try {
+        unlinkSync(path.join(appDir, name));
+      } catch {
+        // Nothing useful to do about one file on the way out.
+      }
+    }
+  } catch {
+    // An unreadable directory is not worth delaying the exit for.
+  }
 }

--- a/src/build-snapshot.ts
+++ b/src/build-snapshot.ts
@@ -1,0 +1,183 @@
+import { readdir, rename } from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * Worker resident memory above which its heap snapshot stops being parseable.
+ *
+ * Measured on 2026-08-19 against the vercel/next.js#97464 reproduction, three
+ * points: a worker at 802 MB wrote 310 MB, at 1201 MB wrote 563 MB, and at
+ * 3010 MB wrote 2388 MB. The ratio is not flat — 0.39x, 0.47x, 0.79x — so the
+ * 512 MB a V8 string can hold is crossed somewhere just past 1 GB of RSS.
+ * A snapshot taken above this is written, costs the disk, and then cannot be
+ * read (see `assertReadableSnapshot`), which is the worst of both.
+ */
+export const PARSEABLE_WORKER_RSS_BYTES = 1024 * 1024 * 1024;
+
+/**
+ * Resident memory below which a worker has not finished loading its own
+ * module graph. A baseline taken there would diff mostly Next booting up.
+ */
+const START_UP_FLOOR_BYTES = 128 * 1024 * 1024;
+
+/**
+ * Growth a pair must bracket to be worth diffing at all. Below this the diff
+ * reports start-up noise dressed as a finding.
+ */
+const MIN_PAIR_GROWTH_BYTES = 128 * 1024 * 1024;
+
+/**
+ * Where the second capture aims.
+ *
+ * An earlier version fired it as soon as the worker had grown past
+ * `MIN_PAIR_GROWTH_BYTES`, which on the #97464 reproduction meant snapshots at
+ * 276 MB and 597 MB — both before the worker reached its first sampled level
+ * of 1637 MB. The diff duly reported 1 MB of `Immediate` objects: the run had
+ * measured the worker booting, not generating pages. The second capture has to
+ * be as late as the parse limit allows, not as early as the growth floor
+ * permits.
+ */
+const AFTER_TARGET_RSS_BYTES = Math.floor(PARSEABLE_WORKER_RSS_BYTES * 0.9);
+
+export type CaptureStage = "waiting" | "baseline-taken" | "pair-taken" | "missed";
+
+export type CaptureDecision = "wait" | "take-baseline" | "take-after" | "give-up";
+
+/**
+ * Decides what to do with a worker at this resident size.
+ *
+ * Both snapshots have to happen low on the curve, which is not where the
+ * interesting memory is. That is forced by the parse limit above and is the
+ * central compromise of build-time attribution: the pair samples the start of
+ * the growth rather than bracketing it, so the report has to say how much of
+ * the curve it actually covers.
+ */
+export function decideCapture(
+  rssBytes: number,
+  stage: CaptureStage,
+  baselineRssBytes: number | null
+): CaptureDecision {
+  if (stage === "pair-taken" || stage === "missed") {
+    return "wait";
+  }
+  if (stage === "waiting") {
+    if (rssBytes > PARSEABLE_WORKER_RSS_BYTES) {
+      // The worker was already past the limit the first time it was seen, so
+      // there is no pair to be had. Saying so beats writing files nobody can
+      // read.
+      return "give-up";
+    }
+    return rssBytes >= START_UP_FLOOR_BYTES ? "take-baseline" : "wait";
+  }
+  const baseline = baselineRssBytes ?? 0;
+  const grown = rssBytes - baseline;
+  if (rssBytes > PARSEABLE_WORKER_RSS_BYTES) {
+    // Last chance: the worker jumped from below the target to past the limit
+    // between two polls. A snapshot at the edge beats no pair at all, provided
+    // the pair spans enough to be about the workload rather than start-up.
+    return grown >= MIN_PAIR_GROWTH_BYTES ? "take-after" : "give-up";
+  }
+  if (rssBytes < AFTER_TARGET_RSS_BYTES) {
+    return "wait";
+  }
+  return grown >= MIN_PAIR_GROWTH_BYTES ? "take-after" : "wait";
+}
+
+/**
+ * V8 writes `--heapsnapshot-signal` output to the process cwd, which for a
+ * static-generation worker is the user's project, under a name carrying the
+ * date, the time, the pid and a sequence number:
+ * `Heap.20260819.013329.17770.0.001.heapsnapshot`. The pid is what keeps two
+ * workers from overwriting each other; the sequence orders one worker's own
+ * captures.
+ */
+const SNAPSHOT_NAME = /^Heap\.\d{8}\.\d{6}\.(\d+)\.\d+\.(\d+)\.heapsnapshot$/;
+
+export function snapshotsWrittenBy(pid: number, filenames: readonly string[]): string[] {
+  return filenames
+    .filter((name) => {
+      const match = SNAPSHOT_NAME.exec(name);
+      return match !== null && Number(match[1]) === pid;
+    })
+    .sort();
+}
+
+export type CollectedPair = {
+  baselineFile: string;
+  afterFile: string;
+};
+
+/**
+ * Moves a worker's two snapshots out of the project and into the run's own
+ * directory. They are the user's source tree's problem otherwise: V8 chose
+ * where to put them, and leaving half a gigabyte of them behind in a repo
+ * would be a poor trade for a measurement.
+ */
+export async function collectSnapshotPair(
+  appDir: string,
+  outDir: string,
+  pid: number
+): Promise<CollectedPair | null> {
+  let entries: string[];
+  try {
+    entries = await readdir(appDir);
+  } catch {
+    return null;
+  }
+  const written = snapshotsWrittenBy(pid, entries);
+  const [baseline, after] = written;
+  if (baseline === undefined || after === undefined) {
+    return null;
+  }
+  const baselineFile = path.join(outDir, `worker-${pid}-baseline.heapsnapshot`);
+  const afterFile = path.join(outDir, `worker-${pid}-after.heapsnapshot`);
+  try {
+    await rename(path.join(appDir, baseline), baselineFile);
+    await rename(path.join(appDir, after), afterFile);
+  } catch {
+    return null;
+  }
+  return { baselineFile, afterFile };
+}
+
+/**
+ * Deletes snapshots a run wrote and cannot use — a give-up after the baseline,
+ * or a worker whose pair never completed. Without this a failed capture leaves
+ * hundreds of megabytes in the user's project with no report referring to them.
+ */
+export async function discardSnapshots(appDir: string, pid: number): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await readdir(appDir);
+  } catch {
+    return;
+  }
+  const { unlink } = await import("node:fs/promises");
+  for (const name of snapshotsWrittenBy(pid, entries)) {
+    try {
+      await unlink(path.join(appDir, name));
+    } catch {
+      // A file that cannot be removed is not worth failing a measurement over.
+    }
+  }
+}
+
+/**
+ * What share of the worker's observed growth the pair actually spans.
+ *
+ * Reported rather than hidden because the parse limit forces the pair low: on
+ * the #97464 reproduction the worker peaks near 3.3 GB and the pair cannot
+ * reach past 1 GB, so the attributed bytes explain a minority of the curve. A
+ * reader comparing the two numbers without this would conclude the rest went
+ * unexplained.
+ */
+export function bracketedShare(
+  baselineRssBytes: number,
+  afterRssBytes: number,
+  peakRssBytes: number
+): number {
+  const total = peakRssBytes - baselineRssBytes;
+  if (total <= 0) {
+    return 1;
+  }
+  return Math.min(1, Math.max(0, (afterRssBytes - baselineRssBytes) / total));
+}

--- a/src/build-snapshot.ts
+++ b/src/build-snapshot.ts
@@ -54,7 +54,7 @@ export type CaptureDecision = "wait" | "take-baseline" | "take-after" | "give-up
 export function decideCapture(
   rssBytes: number,
   stage: CaptureStage,
-  baselineRssBytes: number | null
+  baselineRssBytes: number | null = null
 ): CaptureDecision {
   if (stage === "pair-taken" || stage === "missed") {
     return "wait";
@@ -68,8 +68,7 @@ export function decideCapture(
     }
     return rssBytes >= START_UP_FLOOR_BYTES ? "take-baseline" : "wait";
   }
-  const baseline = baselineRssBytes ?? 0;
-  const grown = rssBytes - baseline;
+  const grown = rssBytes - (baselineRssBytes ?? 0);
   if (rssBytes > PARSEABLE_WORKER_RSS_BYTES) {
     // Last chance: the worker jumped from below the target to past the limit
     // between two polls. A snapshot at the edge beats no pair at all, provided
@@ -92,13 +91,26 @@ export function decideCapture(
  */
 const SNAPSHOT_NAME = /^Heap\.\d{8}\.\d{6}\.(\d+)\.\d+\.(\d+)\.heapsnapshot$/;
 
+/**
+ * Ordered by code unit, deliberately not by `localeCompare`: these names are
+ * fixed-width ASCII, so byte order is capture order, and a locale-aware
+ * collation could reorder digits or punctuation differently per machine. The
+ * baseline has to come first on every machine that runs this.
+ */
+const byCodeUnit = (left: string, right: string): number => {
+  if (left === right) {
+    return 0;
+  }
+  return left < right ? -1 : 1;
+};
+
 export function snapshotsWrittenBy(pid: number, filenames: readonly string[]): string[] {
   return filenames
     .filter((name) => {
       const match = SNAPSHOT_NAME.exec(name);
       return match !== null && Number(match[1]) === pid;
     })
-    .sort();
+    .sort(byCodeUnit);
 }
 
 export type CollectedPair = {

--- a/src/cli-args.test.ts
+++ b/src/cli-args.test.ts
@@ -1,6 +1,21 @@
 import { describe, expect, it } from "vitest";
 import { helpText, parseCliArgs } from "./cli-args.js";
 
+describe("parseCliArgs build command", () => {
+  // Signalling a worker for a heap snapshot can stall the build being measured,
+  // so the curve-and-verdict path has to stay the one you get by default.
+  it("leaves build attribution off unless it is asked for", () => {
+    const plain = parseCliArgs(["build", "./app"]);
+    const asked = parseCliArgs(["build", "./app", "--attribute"]);
+
+    expect(plain).toEqual({
+      kind: "build",
+      options: { appDir: "./app", output: null, attributeBuild: false },
+    });
+    expect(asked.kind === "build" && asked.options.attributeBuild).toBe(true);
+  });
+});
+
 describe("parseCliArgs", () => {
   it("parses a bare app dir with defaults", () => {
     const parsed = parseCliArgs(["./my-app"]);
@@ -18,6 +33,7 @@ describe("parseCliArgs", () => {
         quick: false,
         noResolve: false,
         diffAll: false,
+      attributeBuild: false,
         writeConfig: false,
         output: null,
       },
@@ -45,6 +61,7 @@ describe("parseCliArgs", () => {
       quick: true,
       noResolve: true,
       diffAll: true,
+      attributeBuild: false,
       writeConfig: true,
       output: "/tmp/out",
     });

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -10,6 +10,7 @@ export type CliRunOptions = {
   quick: boolean;
   noResolve: boolean;
   diffAll: boolean;
+  attributeBuild: boolean;
   writeConfig: boolean;
   output: string | null;
 };
@@ -17,6 +18,8 @@ export type CliRunOptions = {
 export type CliBuildOptions = {
   appDir: string;
   output: string | null;
+  /** Opt-in: signal the worker for snapshots and name what it retains. */
+  attributeBuild: boolean;
 };
 
 export type ParsedCli =
@@ -96,6 +99,11 @@ const FLAGS: FlagSpec[] = [
     help: "Fast preset: 2000 requests x 4 cycles, 8s idle — same cycle count as the default, less traffic per cycle",
   },
   { flag: "--diff-all", value: "none", help: "Diff snapshots for stable routes too (slow)" },
+  {
+    flag: "--attribute",
+    value: "none",
+    help: "build only: also name what the worker retains — signals it for heap snapshots, which can stall the build",
+  },
   {
     flag: "--no-resolve",
     value: "none",
@@ -228,6 +236,9 @@ function applyFlag(spec: FlagSpec, value: string, options: CliRunOptions): FlagO
     case "--diff-all":
       options.diffAll = true;
       return FLAG_OK;
+    case "--attribute":
+      options.attributeBuild = true;
+      return FLAG_OK;
     case "--write-config":
       options.writeConfig = true;
       return FLAG_OK;
@@ -300,6 +311,7 @@ export function parseCliArgs(argv: string[]): ParsedCli {
     quick: false,
     noResolve: false,
     diffAll: false,
+    attributeBuild: false,
     writeConfig: false,
     output: null,
   };
@@ -331,7 +343,14 @@ export function parseCliArgs(argv: string[]): ParsedCli {
         message: `option "${misplaced}" shapes HTTP load and does not apply to "next-leak build" — see --help`,
       };
     }
-    return { kind: "build", options: { appDir: options.appDir, output: options.output } };
+    return {
+      kind: "build",
+      options: {
+        appDir: options.appDir,
+        output: options.output,
+        attributeBuild: options.attributeBuild,
+      },
+    };
   }
   return { kind: "run", options };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
-import { writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { attributeBuildCapture } from "./build-attribution.js";
 import { formatBuildReport } from "./build-report.js";
 import { runBuildMeasurement } from "./build-run.js";
 import { helpText, parseCliArgs, type ParsedCli } from "./cli-args.js";
@@ -95,17 +96,28 @@ function handleNonRunCommand(parsed: ParsedCli): boolean {
 }
 
 /**
- * Measuring a build needs no heap headroom of its own: nothing is diffed here,
- * and the memory that matters belongs to the build's own processes.
+ * A build measurement diffs at most one snapshot pair, and the parse limit
+ * keeps that pair below a gigabyte of worker memory, so this needs far less
+ * headroom than a route run. The memory that matters still belongs to the
+ * build's own processes.
  */
-async function runBuildCommand(appDir: string): Promise<void> {
+async function runBuildCommand(appDir: string, outputDir: string | null): Promise<void> {
   const aborter = installInterruptHandlers();
+  const workDir = path.join(
+    outputDir ?? path.join(appDir, ".next-leak"),
+    new Date().toISOString().replace(/[:.]/g, "-")
+  );
+  await mkdir(workDir, { recursive: true });
   const result = await runBuildMeasurement({
     appDir,
+    workDir,
     signal: aborter.signal,
     onProgress: (message) => console.error(`· ${message}`),
   });
-  console.log(formatBuildReport(result));
+  const attribution = await attributeBuildCapture(result, appDir, (message) =>
+    console.error(`· ${message}`)
+  );
+  console.log(formatBuildReport(result, attribution));
   if (aborter.signal.aborted) {
     process.exitCode = 130;
   }
@@ -151,7 +163,7 @@ async function main(): Promise<void> {
     return;
   }
   if (parsed.kind === "build") {
-    await runBuildCommand(parsed.options.appDir);
+    await runBuildCommand(parsed.options.appDir, parsed.options.output);
     return;
   }
   if (parsed.kind !== "run") {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { attributeBuildCapture } from "./build-attribution.js";
 import { formatBuildReport } from "./build-report.js";
 import { runBuildMeasurement } from "./build-run.js";
+import { discardPendingSnapshotsSync } from "./build-snapshot.js";
 import { helpText, parseCliArgs, type ParsedCli } from "./cli-args.js";
 import { checkRuntime } from "./guards.js";
 import { killActiveChildren } from "./launcher.js";
@@ -60,6 +61,9 @@ function installInterruptHandlers(): AbortController {
     process.on(signalName, () => {
       interrupts += 1;
       if (interrupts > 1) {
+        // A build capture may have left a snapshot in the project; this is the
+        // last point where anything can remove it.
+        discardPendingSnapshotsSync();
         process.exit(130);
       }
       console.error("\n· interrupted — stopping the measured process and writing a partial run.json");
@@ -101,7 +105,11 @@ function handleNonRunCommand(parsed: ParsedCli): boolean {
  * headroom than a route run. The memory that matters still belongs to the
  * build's own processes.
  */
-async function runBuildCommand(appDir: string, outputDir: string | null): Promise<void> {
+async function runBuildCommand(
+  appDir: string,
+  outputDir: string | null,
+  attribute: boolean
+): Promise<void> {
   const aborter = installInterruptHandlers();
   const workDir = path.join(
     outputDir ?? path.join(appDir, ".next-leak"),
@@ -110,7 +118,13 @@ async function runBuildCommand(appDir: string, outputDir: string | null): Promis
   await mkdir(workDir, { recursive: true });
   const result = await runBuildMeasurement({
     appDir,
-    workDir,
+    // Capture is opt-in because signalling a worker for a heap snapshot can
+    // stall the build it is measuring. Observed on the #97464 reproduction:
+    // the second signal landed and the worker sat frozen for fourteen minutes
+    // with an empty snapshot file on disk, and on an earlier run for ninety.
+    // A curve and a verdict are what this command promises; naming the objects
+    // is worth asking for, not worth risking every run for.
+    ...(attribute && { workDir }),
     signal: aborter.signal,
     onProgress: (message) => console.error(`· ${message}`),
   });
@@ -163,7 +177,11 @@ async function main(): Promise<void> {
     return;
   }
   if (parsed.kind === "build") {
-    await runBuildCommand(parsed.options.appDir, parsed.options.output);
+    await runBuildCommand(
+      parsed.options.appDir,
+      parsed.options.output,
+      parsed.options.attributeBuild
+    );
     return;
   }
   if (parsed.kind !== "run") {


### PR DESCRIPTION
## What

`next-leak build` reported a curve and a verdict. It can now also say what the
static-generation worker was holding, using the same diff and the same
attribution the runtime path uses.

The build is still unmodified. The worker is Next's own child, so the only
handle on it is a signal: `--heapsnapshot-signal=SIGUSR2` is appended to
`NODE_OPTIONS` (appended, not replaced — a user's own heap cap has to survive),
the worker is signalled twice, and the pair is moved out of the project into the
run directory before being diffed.

On the #97464 reproduction:

```
what it retained, between 205.6 MB and 932.0 MB of worker rss —
19% of the growth this run observed. The rest is not
attributed: a snapshot taken higher up cannot be parsed back.
    ↳ Set 30.3 MB · unattributed
        system / Context#object[.gcPersistentSignals] <- ... <- ClonedAbortSignal
```

## Why

Confirming someone's bug and handing them the object are different
contributions, and the second is what moved things in July.

## What the probes changed

Four questions were measured against the #97464 reproduction before any of this
was written. Two of the answers shaped the feature rather than a parameter.

**A signalled worker survives.** At 73% of its heap cap it still finished the
build. The one run that died reproduced the same SIGABRT with no signal sent, so
capture does not have to be timid.

**Snapshot size is the binding constraint.** The snapshot/RSS ratio is not flat:

| worker rss | snapshot |
|---:|---:|
| 802 MB | 310 MB |
| 1201 MB | 563 MB |
| 3010 MB | 2388 MB |

So the 512 MB a V8 string can hold is crossed just past a gigabyte of worker
memory. Both captures have to happen below that, which means the pair samples
the start of the growth instead of bracketing it. Rather than hide that, the
report states the share it spans — 19% on a reproduction whose worker peaks near
4 GB — so the findings cannot be read as the whole story.

## A threshold that only running it exposed

The first version fired the second capture as soon as the pair had grown 128 MB.
That put both snapshots at 276 MB and 597 MB, below the worker's own first
sampled level of 1637 MB, and the diff duly reported 1 MB of `Immediate`
objects: it had measured the worker booting. Aiming at the parse limit instead
surfaced 30 MB held through `gcPersistentSignals`, reproducible as the top
finding across three runs.

## Field checks

- Three runs on #97464 name the same owner (30.3 / 15.1 / 18.9 MB).
- The 16.2.12 control still reports `stable` at 0.02 MB/page with capture on,
  and produces no attribution section at all, because its worker peaks at
  789 MB and never reaches the capture target. A healthy build stays quiet.
- Nothing is left behind in the project: the pair is moved into the run
  directory, and a capture that does not complete is deleted.

## Checklist

- [x] Tests cover the new behavior
- [x] `pnpm typecheck && pnpm test` pass locally
- [x] Verdict semantics untouched, or the mutation suite was run
