### PR TITLE
fix: judge a snapshot wait by bytes on disk, not the clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,17 @@ through the build's source maps.
   that is almost nothing. A 1342.9 MB capture of a leaking route parsed 2.4 MB
   of JSON and diffs fine; a 2227.5 MB one whose `strings` section alone was
   868.9 MB is refused, and the message names 869 MB rather than 2227 MB.
+- **A slow snapshot is not a failed route.** `v8.writeHeapSnapshot` blocks the
+  measured process until the file is on disk, so the control channel goes
+  silent for as long as the write takes — and the worse the leak, the longer
+  that is. The wait is judged by bytes reaching disk, not by a clock: a
+  snapshot that is still growing is given as long as it needs, while five
+  minutes with nothing written is treated as a wedged process and said so. If
+  the final snapshot cannot be taken at all, the run keeps its verdict — the
+  curve is already complete by then — and reports the missing attribution
+  instead of discarding the route. Measured on the
+  [#84648](https://github.com/vercel/next.js/issues/84648) reproduction, whose
+  4.2 GB capture outlasted every fixed deadline worth setting.
 - **Architectures:** verified on **arm64 and x64** (linux/amd64 in Docker) — same app, same parameters, same verdicts.
 - **Attribution** (naming the file) needs a Turbopack build with server sourcemaps — the Next 15+ default. On webpack builds the registry is empty by design and findings degrade to `unattributed` with raw retainer chains; measurement itself does not depend on it. Note that `output: "standalone"` + `--webpack` produced a bundle that could not start at all on `16.3.0-canary.90` (missing `@swc/helpers`), independently of this tool.
 - Empirically validated on Next **15.5.4, 16.0.x, 16.1.5, 16.2.x, 16.3.0/16.3.1 and 16.3-canary** (incl. Sentry, OpenTelemetry, PPR and i18n apps), against the public reproductions attached to real issues (open and since-fixed). Most recent measurements, 2026-08-17/18: the runtime path on 16.2.12 and 16.3.1-canary.18, the build path on 16.2.12 and 16.3.1. The contracts it relies on are stable since Next 13–14, but older versions are untested.

--- a/src/control-client.test.ts
+++ b/src/control-client.test.ts
@@ -1,11 +1,16 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import http from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   deadlineForOperation,
   requestGc,
   requestMemory,
   requestSnapshot,
+  requestWatchingFile,
   requestWithDeadline,
+  snapshotPathFor,
 } from "./control-client.js";
 
 let server: http.Server | undefined;
@@ -95,7 +100,7 @@ describe("control channel deadlines", () => {
       // Accept the request, never respond: the wedged-child shape.
     });
     await expect(requestWithDeadline(port, "/gc", 200)).rejects.toThrow(
-      /did not answer within 0s — the measured process is wedged, or this snapshot is larger than anything this tool has been validated on/
+      /did not answer within 0s — the measured process is wedged or its event loop is blocked/
     );
   });
 
@@ -122,4 +127,120 @@ describe("control channel deadlines", () => {
     });
     await expect(requestWithDeadline(port, "/mem", 300)).rejects.toThrow(/within 0s/);
   }, 10_000);
+});
+
+/**
+ * `v8.writeHeapSnapshot` blocks the measured process's event loop until the
+ * file is on disk, so the channel goes silent exactly while it is doing the
+ * work. A wall-clock bound cannot tell that apart from a wedged child, and got
+ * it wrong in the direction that matters: measured on the
+ * vercel/next.js#84648 reproduction, the old 1800 s bound failed a leaking
+ * route whose 267 MB snapshot landed intact moments later. The bigger the
+ * leak, the bigger the snapshot — so it failed hardest on the runs worth
+ * keeping. Bytes reaching disk are the heartbeat instead.
+ */
+describe("snapshot waits judged by progress on disk", () => {
+  let dir: string;
+
+  afterEach(async () => {
+    if (dir !== undefined) {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  async function tempDir(): Promise<string> {
+    dir = await mkdtemp(path.join(tmpdir(), "next-leak-watch-"));
+    return dir;
+  }
+
+  it("keeps waiting while the file is still growing, past the stall window", async () => {
+    const workDir = await tempDir();
+    const file = snapshotPathFor(workDir, "after");
+    // Answers only after several stall windows would have expired. A growing
+    // file has to be enough to hold the wait open that long.
+    const port = await listen((_req, res) => {
+      setTimeout(() => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({
+            file,
+            sample: { gcExposed: true, heapUsed: 1, rss: 1, external: 1, arrayBuffers: 1 },
+          })
+        );
+      }, 400);
+    });
+    let bytes = 0;
+    const growing = setInterval(() => {
+      bytes += 1024;
+      void writeFile(file, Buffer.alloc(bytes));
+    }, 20);
+    try {
+      const answer = await requestWatchingFile(port, "/snapshot?name=after", 60_000, {
+        file,
+        stallMs: 100,
+        hardCapMs: 60_000,
+        pollMs: 10,
+      });
+      expect(answer).toMatchObject({ file });
+    } finally {
+      clearInterval(growing);
+    }
+  });
+
+  it("gives up on a file that stops growing, and says how far it got", async () => {
+    const workDir = await tempDir();
+    const file = snapshotPathFor(workDir, "after");
+    await writeFile(file, Buffer.alloc(2 * 1_048_576));
+    const port = await listen(() => {
+      // Accept and never answer: the wedged-child shape.
+    });
+    await expect(
+      requestWatchingFile(port, "/snapshot?name=after", 60_000, {
+        file,
+        stallMs: 100,
+        hardCapMs: 60_000,
+        pollMs: 10,
+      })
+    ).rejects.toThrow(/wrote nothing for 0s \(2\.0 MB on disk\) — the measured process is wedged/);
+  });
+
+  it("still ends an unattended run when the file grows forever", async () => {
+    const workDir = await tempDir();
+    const file = snapshotPathFor(workDir, "after");
+    const port = await listen(() => {
+      // Never answers; the file below never stops growing either.
+    });
+    let bytes = 0;
+    const growing = setInterval(() => {
+      bytes += 1024;
+      void writeFile(file, Buffer.alloc(bytes));
+    }, 10);
+    try {
+      await expect(
+        requestWatchingFile(port, "/snapshot?name=after", 60_000, {
+          file,
+          stallMs: 60_000,
+          hardCapMs: 200,
+          pollMs: 10,
+        })
+      ).rejects.toThrow(/was still writing after .* — giving up so an unattended run can end/);
+    } finally {
+      clearInterval(growing);
+    }
+  });
+
+  it("reports nothing written when the snapshot file never appears", async () => {
+    const workDir = await tempDir();
+    const port = await listen(() => {
+      // Accept and never answer, with no file ever created.
+    });
+    await expect(
+      requestWatchingFile(port, "/snapshot?name=after", 60_000, {
+        file: snapshotPathFor(workDir, "after"),
+        stallMs: 100,
+        hardCapMs: 60_000,
+        pollMs: 10,
+      })
+    ).rejects.toThrow(/nothing written yet/);
+  });
 });

--- a/src/control-client.ts
+++ b/src/control-client.ts
@@ -1,4 +1,6 @@
+import { stat } from "node:fs/promises";
 import http from "node:http";
+import path from "node:path";
 import { z } from "zod";
 import type { HeapSample } from "./control-server.js";
 
@@ -45,6 +47,73 @@ function deadlineFor(pathname: string): number {
 }
 
 /**
+ * A wall-clock bound cannot tell a wedged child from a working one, and for
+ * `/snapshot` that difference decides whether a route gets a verdict.
+ *
+ * `v8.writeHeapSnapshot` blocks the child's event loop until the file is on
+ * disk, so the channel goes silent exactly while the tool is being served.
+ * Measured on the vercel/next.js#84648 reproduction: the 1800 s bound expired
+ * on a route that was leaking hard, and the 267 MB snapshot (against a 39 MB
+ * baseline) landed intact afterwards — the run was thrown away for finishing
+ * late. The worse the leak, the bigger the snapshot, so the old bound failed
+ * most reliably on the runs that mattered most.
+ *
+ * The file itself is the heartbeat: bytes arriving mean the child is working,
+ * however long it takes. Silence on disk for this long means it is not.
+ */
+const SNAPSHOT_STALL_MS = 300_000;
+/** Polling interval for that heartbeat. Cheap: one `stat` per tick. */
+const SNAPSHOT_POLL_MS = 10_000;
+/**
+ * Absolute ceiling, progress or not. The stall window alone would let a child
+ * that trickles a byte a minute hold an unattended run open forever.
+ */
+const SNAPSHOT_HARD_CAP_MS = 14_400_000;
+
+/** Where the control server will put `<name>.heapsnapshot`, so the client can watch it grow. */
+export function snapshotPathFor(workDir: string, name: string): string {
+  return path.join(workDir, `${path.basename(name)}.heapsnapshot`);
+}
+
+/** Judging a wait by bytes on disk instead of by the clock. */
+export type SnapshotWatch = {
+  /** The file the measured process is writing. */
+  file: string;
+  /** Give up after this long with no new bytes. */
+  stallMs: number;
+  /** Give up after this long regardless of progress. */
+  hardCapMs: number;
+  /** How often to look. */
+  pollMs: number;
+};
+
+function productionWatch(file: string): SnapshotWatch {
+  return {
+    file,
+    stallMs: SNAPSHOT_STALL_MS,
+    hardCapMs: SNAPSHOT_HARD_CAP_MS,
+    pollMs: SNAPSHOT_POLL_MS,
+  };
+}
+
+/** Bytes on disk so far, or null while the file does not exist yet. */
+async function bytesWritten(file: string): Promise<number | null> {
+  try {
+    return (await stat(file)).size;
+  } catch {
+    return null;
+  }
+}
+
+function describeProgress(bytes: number): string {
+  return bytes < 0 ? "nothing written yet" : `${(bytes / 1_048_576).toFixed(1)} MB on disk`;
+}
+
+function describeDuration(ms: number): string {
+  return ms >= 3_600_000 ? `${Math.round(ms / 3_600_000)}h` : `${Math.round(ms / 1000)}s`;
+}
+
+/**
  * One loopback GET with this tool's own deadline and nothing else's.
  *
  * `socket.setTimeout` alone is not enough: it fires on idle and a
@@ -55,7 +124,8 @@ function deadlineFor(pathname: string): number {
 function get(
   port: number,
   pathname: string,
-  deadlineMs: number
+  deadlineMs: number,
+  watch?: SnapshotWatch
 ): Promise<{ status: number; body: string }> {
   return new Promise((resolve, reject) => {
     let settled = false;
@@ -64,7 +134,7 @@ function get(
         return;
       }
       settled = true;
-      clearTimeout(timer);
+      stopTimer();
       if ("ok" in outcome) {
         resolve(outcome.ok);
       } else {
@@ -80,20 +150,67 @@ function get(
         })
       );
     });
-    // The timer rejects directly instead of waiting for a destroy-triggered
+    // Giving up rejects directly instead of waiting for a destroy-triggered
     // error event: destroying a request whose response already started does
     // not reliably emit one, and a deadline that only sometimes fires is no
     // deadline at all.
-    const timer = setTimeout(() => {
+    const giveUp = (reason: string): void => {
       settle({
-        error: new ControlError(
-          `control channel ${pathname} on port ${port} did not answer within ` +
-            `${Math.round(deadlineMs / 1000)}s — the measured process is wedged, or this ` +
-            `snapshot is larger than anything this tool has been validated on`
-        ),
+        error: new ControlError(`control channel ${pathname} on port ${port} ${reason}`),
       });
       request.destroy();
-    }, deadlineMs);
+    };
+
+    let timer: NodeJS.Timeout;
+    let stopTimer: () => void;
+    if (watch === undefined) {
+      timer = setTimeout(
+        () =>
+          giveUp(
+            `did not answer within ${Math.round(deadlineMs / 1000)}s — the measured process ` +
+              `is wedged or its event loop is blocked`
+          ),
+        deadlineMs
+      );
+      stopTimer = (): void => clearTimeout(timer);
+    } else {
+      // Watch the file, not the clock. A snapshot still growing is a child
+      // doing exactly what it was asked, with its event loop blocked — which
+      // is the normal way this call succeeds, not a failure to wait out.
+      const startedAt = Date.now();
+      let lastSize = -1;
+      let lastGrewAt = startedAt;
+      let checking = false;
+      const check = async (): Promise<void> => {
+        if (checking || settled) {
+          return;
+        }
+        checking = true;
+        try {
+          const size = await bytesWritten(watch.file);
+          const now = Date.now();
+          if (size !== null && size > lastSize) {
+            lastSize = size;
+            lastGrewAt = now;
+          }
+          if (now - startedAt >= watch.hardCapMs) {
+            giveUp(
+              `was still writing after ${describeDuration(watch.hardCapMs)} ` +
+                `(${describeProgress(lastSize)}) — giving up so an unattended run can end`
+            );
+          } else if (now - lastGrewAt >= watch.stallMs) {
+            giveUp(
+              `wrote nothing for ${describeDuration(watch.stallMs)} ` +
+                `(${describeProgress(lastSize)}) — the measured process is wedged`
+            );
+          }
+        } finally {
+          checking = false;
+        }
+      };
+      timer = setInterval(() => void check(), watch.pollMs);
+      stopTimer = (): void => clearInterval(timer);
+    }
     timer.unref();
     // Bare "fetch failed" read like a bug in this tool. Name the channel
     // and the operation: the usual cause is the measured process dying,
@@ -112,9 +229,10 @@ function get(
 async function request(
   port: number,
   pathname: string,
-  deadlineMs = deadlineFor(pathname)
+  deadlineMs = deadlineFor(pathname),
+  watch?: SnapshotWatch
 ): Promise<unknown> {
-  const response = await get(port, pathname, deadlineMs);
+  const response = await get(port, pathname, deadlineMs, watch);
   if (response.status !== 200) {
     throw new ControlError(`control channel ${pathname} responded ${response.status}`);
   }
@@ -144,13 +262,27 @@ export async function requestMemory(port: number): Promise<HeapSample> {
   return sampleSchema.parse(await request(port, "/mem"));
 }
 
-/** Forces GC, writes a named heap snapshot, and returns its path and sample. */
+/**
+ * Forces GC, writes a named heap snapshot, and returns its path and sample.
+ *
+ * Pass `workDir` — the same directory the control server writes into — to have
+ * the wait judged by bytes reaching disk rather than by the clock. Without it
+ * the call falls back to the plain wall-clock bound, which cannot tell a big
+ * snapshot from a wedged process.
+ */
 export async function requestSnapshot(
   port: number,
-  name: string
+  name: string,
+  workDir?: string
 ): Promise<{ file: string; sample: HeapSample }> {
+  const pathname = `/snapshot?name=${encodeURIComponent(name)}`;
   const parsed = snapshotResponseSchema.parse(
-    await request(port, `/snapshot?name=${encodeURIComponent(name)}`)
+    await request(
+      port,
+      pathname,
+      deadlineFor(pathname),
+      workDir === undefined ? undefined : productionWatch(snapshotPathFor(workDir, name))
+    )
   );
   if (!parsed.sample.gcExposed) {
     throw new ControlError(
@@ -162,6 +294,14 @@ export async function requestSnapshot(
 
 /** Test seam: the production deadlines would make a hung-server test take minutes. */
 export const requestWithDeadline = request;
+
+/**
+ * Test seam for the disk-progress watch. Same reason as the deadline seam: the
+ * production stall window is five minutes, and the behaviour worth proving —
+ * that a growing file buys more time and a still one does not — is about the
+ * shape of the wait, not its length.
+ */
+export const requestWatchingFile = request;
 
 /**
  * Test seam for the deadline table itself. A mutation run showed the mapping

--- a/src/report.test.ts
+++ b/src/report.test.ts
@@ -567,6 +567,29 @@ describe("attribution gaps in the summary", () => {
   it("says nothing when every measured route was attributable", () => {
     expect(formatReport(makeRunReport())).not.toContain("finished without attribution");
   });
+
+  // "Could not be read" sends the reader looking for a file that was never
+  // written. The two failures need different next steps, so they read
+  // differently.
+  it("says a snapshot was never taken, rather than never read", () => {
+    const run = makeRunReport();
+    const routes = run.routes.map((route) =>
+      route.status === "measured" && route.route === "/leaky"
+        ? {
+            ...route,
+            diff: null,
+            attributionGap: {
+              reason: "snapshot-unavailable" as const,
+              detail: "control channel /snapshot?name=after wrote nothing for 300s",
+            },
+          }
+        : route
+    );
+    const output = formatReport({ ...run, routes });
+
+    expect(output).toContain("their final snapshot could not be taken");
+    expect(output).not.toContain("their snapshot could not be read");
+  });
 });
 
 // A page of `stable` verdicts is the one output that reads the same whether

--- a/src/report.ts
+++ b/src/report.ts
@@ -355,9 +355,21 @@ function attributionGapLine(report: RunReport): string[] {
     return [];
   }
   const names = gaps.map((route) => route.route).join(", ");
+  // Two different failures, and the difference tells the reader what to try
+  // next: an unreadable snapshot is on disk and too big to parse, a missing
+  // one was never written because the process would not hand it over.
+  const unwritten = gaps.filter(
+    (route) => route.status === "measured" && route.attributionGap?.reason === "snapshot-unavailable"
+  ).length;
+  const cause =
+    unwritten === gaps.length
+      ? "their final snapshot could not be taken"
+      : unwritten === 0
+        ? "their snapshot could not be read"
+        : "their final snapshot could not be taken or read";
   return [
-    `${gaps.length} route(s) finished without attribution because their snapshot ` +
-      `could not be read (${names}) — the verdicts stand, what retains the memory is unnamed`,
+    `${gaps.length} route(s) finished without attribution because ${cause} ` +
+      `(${names}) — the verdicts stand, what retains the memory is unnamed`,
   ];
 }
 

--- a/src/ritual.test.ts
+++ b/src/ritual.test.ts
@@ -33,6 +33,8 @@ async function makeHarness(
     failLoadCall?: number;
     underLoadHeap?: number;
     failMemory?: boolean;
+    /** Refuse the snapshot with this label, as a wedged child would. */
+    failSnapshot?: string;
     /** Per-poll /gc readings; overrides the per-cycle script when present. */
     gcPollScript?: number[];
   } = {}
@@ -87,6 +89,11 @@ async function makeHarness(
     }
     const name = url.searchParams.get("name") ?? "?";
     events.push(`snapshot:${name}`);
+    if (options.failSnapshot === name) {
+      response.statusCode = 500;
+      response.end(JSON.stringify({ error: "wedged" }));
+      return;
+    }
     response.end(JSON.stringify({ file: `/fake/${name}.heapsnapshot`, sample }));
   });
   const controlPort = await new Promise<number>((resolve, reject) => {
@@ -410,6 +417,24 @@ describe("peak capture", () => {
     // the empty peak says plainly that nothing was read.
     expect(result.trend.verdict).toBe("leak");
     expect(result.peaks.every((peak) => peak.polls === 0)).toBe(true);
+  });
+
+  it("keeps the verdict when the final snapshot cannot be taken", async () => {
+    // The curve is complete by the time the last snapshot is asked for, so
+    // losing it must cost the attribution and nothing else. Measured on
+    // vercel/next.js#84648, where the whole route was reported as a failure
+    // because its snapshot arrived after the deadline.
+    harness = await makeHarness([29 * MB, 31 * MB, 33 * MB, 35 * MB], {
+      failSnapshot: "after",
+    });
+    const result = await runRitual(await baseOptions(), harness.deps);
+
+    expect(result.trend.verdict).toBe("leak");
+    expect(result.afterSnapshot).toBe("");
+    expect(result.snapshotFailure).toMatch(/responded 500/);
+    // The last point still exists — taken by a plain GC instead of a snapshot —
+    // so the series is baseline plus one per cycle, exactly as a clean run.
+    expect(result.memorySamples).toHaveLength(5);
   });
 });
 

--- a/src/ritual.ts
+++ b/src/ritual.ts
@@ -160,7 +160,14 @@ export type RitualResult = {
   /** Trend over `unreclaimedSamples`. Reported, never the verdict. */
   unreclaimedTrend: TrendResult;
   baselineSnapshot: string;
+  /**
+   * Empty when the final snapshot could not be taken. The curve is already
+   * complete by then, so the run still has a verdict — only the attribution
+   * is lost. `snapshotFailure` says why.
+   */
   afterSnapshot: string;
+  /** Why `afterSnapshot` is empty, when it is. */
+  snapshotFailure?: string;
   trend: TrendResult;
   requestsPerCycle: number;
   /**
@@ -430,6 +437,7 @@ export async function runRitual(
   let unreclaimedLost = false;
   const peaks: PeakSample[] = [];
   let afterSnapshot = "";
+  let snapshotFailure: string | undefined;
   let baselineSnapshot = "";
   let cyclesCompleted = 0;
 
@@ -445,7 +453,7 @@ export async function runRitual(
       })
     );
     const baseline = await timed("baseline snapshot", () =>
-      requestSnapshot(app.controlPort, "baseline")
+      requestSnapshot(app.controlPort, "baseline", options.workDir)
     );
 
     memorySamples.push(baseline.sample);
@@ -485,11 +493,20 @@ export async function runRitual(
       settleOutcomes.push({ phase: `cycle ${cycle}`, ...settle });
 
       if (cycle === cycles) {
-        const after = await timed("after snapshot", () =>
-          requestSnapshot(app.controlPort, "after")
-        );
-        afterSnapshot = after.file;
-        memorySamples.push(after.sample);
+        // The curve is complete except for this last point, so a failure here
+        // must not cost the whole route. Fall back to a plain GC sample: the
+        // verdict survives, only the diff — and with it the attribution — is
+        // lost. Same trade the diff step already makes one stage later.
+        try {
+          const after = await timed("after snapshot", () =>
+            requestSnapshot(app.controlPort, "after", options.workDir)
+          );
+          afterSnapshot = after.file;
+          memorySamples.push(after.sample);
+        } catch (cause) {
+          snapshotFailure = cause instanceof Error ? cause.message : String(cause);
+          memorySamples.push(await requestGc(app.controlPort));
+        }
       } else {
         memorySamples.push(await requestGc(app.controlPort));
       }
@@ -526,6 +543,7 @@ export async function runRitual(
           ),
       baselineSnapshot,
       afterSnapshot,
+      ...(snapshotFailure !== undefined && { snapshotFailure }),
       trend: classifyMemoryTrend(samples, externalSamples, trendOptions),
       requestsPerCycle: loadRequests,
       minGrowthPerCycle,

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -1389,6 +1389,38 @@ describe("attribution gaps are distinguishable", () => {
     expect(route.attributionGap).toBeUndefined();
   });
 
+  it("records a snapshot that was never taken as its own kind of gap", async () => {
+    // Distinct from `snapshot-unreadable`: there is no file to parse, because
+    // the measured process never handed one over. The cycles that did complete
+    // still carry a verdict, and the run must keep it — reported on
+    // vercel/next.js#84648, where the route came back as a bare failure.
+    const appDir = await makeAppDir({ "/leaky/page": "app/leaky/page.js" });
+    let diffed = false;
+    const report = await runMeasurement(
+      { appDir, bootstrapPath: "/fake/bootstrap.js" },
+      {
+        ...makeDeps([]),
+        ritual: async (options) => ({
+          ...ritualResult(options.route, [29 * MB, 31 * MB, 33 * MB, 35 * MB]),
+          afterSnapshot: "",
+          snapshotFailure: "control channel /snapshot?name=after wrote nothing for 300s",
+        }),
+        diff: async () => {
+          diffed = true;
+          throw new Error("must not diff without a snapshot");
+        },
+      }
+    );
+
+    const route = report.routes[0];
+    if (route?.status !== "measured") throw new Error("route should be measured");
+    expect(route.trend.verdict).toBe("leak");
+    expect(route.attributionGap?.reason).toBe("snapshot-unavailable");
+    expect(route.attributionGap?.detail).toContain("wrote nothing for 300s");
+    expect(route.diff).toBeNull();
+    expect(diffed).toBe(false);
+  });
+
   it("persists the gap to run.json", async () => {
     const { SnapshotError } = await import("./heap-diff.js");
     const report = await runWithDiff(async () => {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -155,7 +155,12 @@ export type RouteReport =
        * attribute.
        */
       attributionGap?: {
-        reason: "snapshot-unreadable";
+        /**
+         * `snapshot-unreadable`: both snapshots exist, the diff refused them.
+         * `snapshot-unavailable`: the final snapshot was never taken, so there
+         * is nothing to diff. Either way the verdict below still stands.
+         */
+        reason: "snapshot-unreadable" | "snapshot-unavailable";
         detail: string;
       };
       /** Null when there is no diff or no module registry. */
@@ -513,7 +518,16 @@ async function measureRoute(
 
   let diff: HeapDiff | null = null;
   let attributionGap: MeasuredRoute["attributionGap"];
-  if (verdict !== "stable" || options.diffAll === true) {
+  if (result.snapshotFailure !== undefined) {
+    // The measurement finished; only its last snapshot did not. Say so and
+    // keep the verdict, rather than reporting the route as a failure and
+    // throwing away every cycle that did complete.
+    attributionGap = {
+      reason: "snapshot-unavailable",
+      detail: result.snapshotFailure,
+    };
+    progress(`no snapshot to attribute for ${route.path}: ${result.snapshotFailure}`);
+  } else if (verdict !== "stable" || options.diffAll === true) {
     progress(`diffing snapshots for ${route.path}`);
     try {
       diff = await deps.diff(result.baselineSnapshot, result.afterSnapshot);


### PR DESCRIPTION
## The bug

`v8.writeHeapSnapshot` is synchronous: it blocks the measured process's event
loop until the file is on disk. The control channel therefore goes silent
*precisely while it is doing the work it was asked to do*, and the 1800 s
wall-clock bound could not tell that apart from a wedged child.

It failed in the worst possible direction. The bigger the leak, the bigger the
snapshot, so the bound broke down hardest on exactly the runs worth keeping.
Measured on the [#84648](https://github.com/vercel/next.js/issues/84648)
reproduction: a leaking route came back as `failed` while its 267 MB snapshot
(against a 39 MB baseline) landed intact moments later. The error message even
offered both hypotheses — *"the measured process is wedged, or this snapshot is
larger than…"* — but nothing in the code distinguished them.

## The fix

**The file is the heartbeat.** The client predicts where the control server
will write (`snapshotPathFor`) and watches it grow. Bytes arriving mean the
child is working, however long that takes; five minutes with nothing new means
it is not. A four-hour ceiling still ends an unattended run. The two give-up
messages now say which happened, and how far the snapshot got.

**Losing the last snapshot no longer costs the route.** The curve is complete
by the time it is requested, so the ritual falls back to a plain `requestGc`
and keeps its verdict, reporting the missing attribution as a new
`snapshot-unavailable` gap — distinct from `snapshot-unreadable`, where a file
exists but cannot be parsed. This is the same trade the diff step already makes
one stage later.

The thresholds are injectable (`SnapshotWatch`), mirroring the existing
deadline seam, so the tests prove the *shape* of the wait — a growing file buys
time, a still one does not — without taking five minutes to run.

## Verification

752/752 tests (7 new), typecheck and build clean.

Field-verified against the #84648 reproduction (Next 16.3.1, React 19.2.8,
`force-dynamic` + cookies + i18n, abandoned 200 ms after the request), running
the same command that previously died:

| | before | after |
|---|---|---|
| final snapshot | aborted at 1800 s | captured, **4.2 GB** |
| measurement | discarded | intact |
| output | `failed`, nothing else | `inconclusive` (+6.67 MB/1000 req), full report |

The diff does still fail afterwards — on the already-known 512 MB V8 string
ceiling — and there the existing `attributionGap` does its job and suggests
`--requests 2300`. A failure in the extra step no longer takes the measurement
down with it.
