### PR TITLE
feat(trend): stop calling a saturated curve a leak, and repeat before judging

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Every report prints the gate it used.
 |---|---|---|
 | `--routes <list>` | all | Only measure these routes (comma-separated templates or prefixes) |
 | `--cycles <n>` | 4 | Load cycles per route (min 3). The first is dropped as warm-up, so the verdict sees `n − 1` deltas — at 3 it sees two |
+| `--repeat <n>` | 1 | Measure each route `n` times, each from a fresh server, and judge it on all of them (max 10). The run takes `n` times as long. Routes whose repetitions disagree are reported `inconclusive`, and the spread of growth rates is printed either way. More cycles watch one process for longer; repetitions watch different ones, which is where the variance lives — three runs of one Next build measured 602, 826 and 875 MB retained, and a fourth measured 39 MB |
 | `--requests <n>` | 5000 | Requests per cycle. Raises sensitivity as well as duration: the growth gate scales with it, down to a noise floor around 5000 |
 | `--connections <n>` | 100 | Concurrent connections |
 | `--idle <seconds>` | 30 | **Maximum** wait before each sample; the run continues as soon as the heap settles |

--- a/src/cli-args.test.ts
+++ b/src/cli-args.test.ts
@@ -25,6 +25,7 @@ describe("parseCliArgs", () => {
         appDir: "./my-app",
         routes: null,
         cycles: null,
+        repeat: null,
         requests: null,
         connections: null,
         idleSeconds: null,
@@ -43,7 +44,7 @@ describe("parseCliArgs", () => {
 
   it("parses every flag", () => {
     const parsed = parseCliArgs([
-      "app", "--routes", "/api,/dashboard", "--cycles", "6", "--requests", "1000",
+      "app", "--routes", "/api,/dashboard", "--cycles", "6", "--repeat", "3", "--requests", "1000",
       "--connections", "20", "--idle", "8", "--warmup", "50", "--max-old-space", "2048", "--quick",
       "--diff-all", "--no-resolve", "--self-check", "--write-config", "--output", "/tmp/out",
     ]);
@@ -54,6 +55,7 @@ describe("parseCliArgs", () => {
       appDir: "app",
       routes: ["/api", "/dashboard"],
       cycles: 6,
+      repeat: 3,
       requests: 1000,
       connections: 20,
       idleSeconds: 8,
@@ -174,6 +176,16 @@ describe("parseCliArgs message and boundary precision", () => {
   it("accepts exactly 3 cycles and rejects 2 with the verdict rationale", () => {
     expect(parseCliArgs(["app", "--cycles", "3"]).kind).toBe("run");
     expect(errorMessage(["app", "--cycles", "2"])).toContain("at least 3 cycles");
+  });
+
+  // Repetitions cost a whole measurement each, so the cap is about the clock
+  // rather than about memory: past ten, the runtime is the finding.
+  it("bounds --repeat at both ends", () => {
+    expect(parseCliArgs(["app", "--repeat", "1"]).kind).toBe("run");
+    expect(parseCliArgs(["app", "--repeat", "10"]).kind).toBe("run");
+    expect(errorMessage(["app", "--repeat", "0"])).toContain("positive integer");
+    expect(errorMessage(["app", "--repeat", "11"])).toContain("capped at 10");
+    expect(errorMessage(["app", "--repeat", "2.5"])).toContain("positive integer");
   });
 
   // The measured app used to be pinned at 512 MB with no way out: an app whose

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -2,6 +2,15 @@ export type CliRunOptions = {
   appDir: string;
   routes: string[] | null;
   cycles: number | null;
+  /**
+   * How many times to measure each route, from a fresh server each time.
+   *
+   * More cycles watch one process for longer; repetitions watch different
+   * processes. The spreads that make a verdict unpublishable live between
+   * processes: vercel/next.js#84648 gave 602, 826 and 875 MB on three runs of
+   * one build and 39 MB on a fourth.
+   */
+  repeat: number | null;
   requests: number | null;
   connections: number | null;
   idleSeconds: number | null;
@@ -41,6 +50,7 @@ const BUILD_COMMAND = "build";
 const RUN_ONLY_FLAGS: ReadonlyArray<[keyof CliRunOptions, string]> = [
   ["routes", "--routes"],
   ["cycles", "--cycles"],
+  ["repeat", "--repeat"],
   ["requests", "--requests"],
   ["connections", "--connections"],
   ["idleSeconds", "--idle"],
@@ -80,6 +90,14 @@ const FLAGS: FlagSpec[] = [
     help: "Only measure these routes — comma-separated templates or prefixes (e.g. /api,/dashboard)",
   },
   { flag: "--cycles", value: "int", argName: "<n>", help: "Load cycles per route (default 4, minimum 3)" },
+  {
+    flag: "--repeat",
+    value: "int",
+    argName: "<n>",
+    help:
+      "Measure each route n times from a fresh server (default 1) — the run takes n times as long, " +
+      "and routes whose repetitions disagree are reported inconclusive",
+  },
   { flag: "--requests", value: "int", argName: "<n>", help: "Requests per cycle (default 5000)" },
   { flag: "--connections", value: "int", argName: "<n>", help: "Concurrent connections (default 100)" },
   { flag: "--idle", value: "int", argName: "<seconds>", help: "Idle seconds before each sample (default 30)" },
@@ -164,6 +182,7 @@ interrupted, 1 on errors.
 /** Upper bounds that keep a mistyped digit from starting a run that never ends. */
 const LIMITS: Record<string, number | undefined> = {
   "--cycles": 100,
+  "--repeat": 10,
   "--requests": 1_000_000,
   "--connections": 10_000,
   "--idle": 3_600,
@@ -218,6 +237,7 @@ function applyNumericFlag(flag: string, value: string, options: CliRunOptions): 
     );
   }
   if (flag === "--cycles") options.cycles = parsed;
+  if (flag === "--repeat") options.repeat = parsed;
   if (flag === "--requests") options.requests = parsed;
   if (flag === "--connections") options.connections = parsed;
   if (flag === "--idle") options.idleSeconds = parsed;
@@ -231,6 +251,7 @@ function applyFlag(spec: FlagSpec, value: string, options: CliRunOptions): FlagO
     case "--routes":
       return applyRoutesFlag(value, options);
     case "--cycles":
+    case "--repeat":
     case "--requests":
     case "--connections":
     case "--idle":
@@ -313,6 +334,7 @@ export function parseCliArgs(argv: string[]): ParsedCli {
     appDir: "",
     routes: null,
     cycles: null,
+    repeat: null,
     requests: null,
     connections: null,
     idleSeconds: null,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -248,6 +248,7 @@ async function main(): Promise<void> {
     ...quickPreset,
     ...(options.routes !== null && { routeFilter: options.routes }),
     ...(options.cycles !== null && { cycles: options.cycles }),
+    ...(options.repeat !== null && { repeat: options.repeat }),
     ...(options.requests !== null && { loadRequests: options.requests }),
     ...(options.connections !== null && { connections: options.connections }),
     ...(options.idleSeconds !== null && { idleMs: options.idleSeconds * 1000 }),

--- a/src/confidence.ts
+++ b/src/confidence.ts
@@ -31,7 +31,16 @@ export type WarningCode =
   | "near-threshold"
   | "thin-evidence"
   | "near-heap-ceiling"
-  | "warm-up-baseline";
+  | "warm-up-baseline"
+  /**
+   * Repeated measurements of the same route did not agree.
+   *
+   * More cycles watch one process for longer; repetitions watch different
+   * ones, and that is where the spread lives — vercel/next.js#84648 gave 602,
+   * 826 and 875 MB on three runs of one build and 39 MB on a fourth. A verdict
+   * a second run contradicts is not a verdict.
+   */
+  | "repetitions-disagree";
 
 export type MeasurementWarning = {
   code: WarningCode;
@@ -102,6 +111,7 @@ const VERDICT_WEAKENING: ReadonlySet<WarningCode> = new Set([
   "near-threshold",
   "spiky-growth",
   "thin-evidence",
+  "repetitions-disagree",
 ]);
 
 /**

--- a/src/report.test.ts
+++ b/src/report.test.ts
@@ -628,3 +628,39 @@ describe("harness verification in the summary", () => {
     expect(formatReport(makeRunReport())).not.toContain("nothing verified the harness");
   });
 });
+
+describe("formatReport repetitions", () => {
+  const withRepetitions = (repetitions: unknown) => {
+    const report = makeRunReport();
+    const leaky = report.routes[1];
+    if (leaky?.status !== "measured") throw new Error("fixture broken");
+    leaky.repetitions = repetitions as never;
+    return formatReport(report);
+  };
+
+  it("says nothing when the route was measured once", () => {
+    expect(formatReport(makeRunReport())).not.toContain("repetitions");
+  });
+
+  // Same verdict, different magnitudes: the case vercel/next.js#97424 produced,
+  // where two runs read 14.3 and 14.4 and a third read 6.5.
+  it("prints the spread even when every repetition agreed", () => {
+    const output = withRepetitions([
+      { verdict: "leak", growthPer1000Requests: 0.5 * MB },
+      { verdict: "leak", growthPer1000Requests: 1.25 * MB },
+      { verdict: "leak", growthPer1000Requests: 0.8 * MB },
+    ]);
+    expect(output).toContain("across 3 repetitions");
+    expect(output).toContain("all 3 agreed on leak");
+    expect(output).toContain("+0.50 to +1.25 MB/1000 req");
+  });
+
+  it("names the verdicts when repetitions disagree", () => {
+    const output = withRepetitions([
+      { verdict: "leak", growthPer1000Requests: 0.9 * MB },
+      { verdict: "stable", growthPer1000Requests: 0.02 * MB },
+    ]);
+    expect(output).toContain("they disagreed (leak, stable)");
+    expect(output).toContain("no single verdict is reported");
+  });
+});

--- a/src/report.ts
+++ b/src/report.ts
@@ -86,6 +86,31 @@ function revalidationLines(route: MeasuredRouteView): string[] {
  * Next 16.3.3, all of it the cache; the same route with the payload removed
  * measured +88 MB. Without saying so, the first number reads as a leak.
  */
+/**
+ * What repeated measurements of this route came out as.
+ *
+ * Printed even when every repetition agreed, because agreeing on the verdict
+ * is not agreeing on the number: vercel/next.js#97424 produced the same
+ * verdict across runs whose retained-per-render differed by 2.5×. Publishing
+ * the midpoint of that as a measurement is the error this exists to prevent.
+ */
+function repetitionLines(route: MeasuredRouteView): string[] {
+  const repetitions = route.repetitions;
+  if (repetitions === undefined || repetitions.length < 2) {
+    return [];
+  }
+  const rates = repetitions.map((entry) => entry.growthPer1000Requests);
+  const low = Math.min(...rates);
+  const high = Math.max(...rates);
+  const verdicts = [...new Set(repetitions.map((entry) => entry.verdict))];
+  const agreement =
+    verdicts.length === 1
+      ? `all ${repetitions.length} agreed on ${verdicts[0]}`
+      : `they disagreed (${verdicts.join(", ")}), so no single verdict is reported`;
+  const range = `${low >= 0 ? "+" : ""}${(low / MB).toFixed(2)} to ${formatGrowth(high)}`;
+  return [`      across ${repetitions.length} repetitions: ${range} — ${agreement}`];
+}
+
 function cacheLines(route: MeasuredRouteView): string[] {
   const lines: string[] = [];
   if (route.trend.verdict === "saturating") {
@@ -267,6 +292,7 @@ function routeLines(route: RouteReport, parameters: RunParameters): string[] {
     `  ${VERDICT_ICON[verdict]} ${route.route}  ${verdict}  (${formatGrowth(
       route.growthPer1000Requests
     )})  heap ${curve}${resolved}`,
+    ...repetitionLines(route),
     ...revalidationLines(route),
     ...cacheLines(route),
     ...abandonLines(route),

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -4,13 +4,18 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { RitualResult } from "./ritual.js";
 import {
+  aggregateRepetitions,
   estimateRun,
   formatDuration,
   formatEstimate,
   routeSlug,
   runMeasurement,
+  type RouteReport,
   type RunnerDeps,
 } from "./runner.js";
+import { warrantsIssueDraft } from "./confidence.js";
+import { makeRunReport } from "./run-report.fixture.js";
+import type { TrendVerdict } from "./trend.js";
 
 const MB = 1024 * 1024;
 const FIXTURES = new URL("./__fixtures__/", import.meta.url);
@@ -1431,5 +1436,121 @@ describe("attribution gaps are distinguishable", () => {
     ) as { routes: { attributionGap?: { reason: string } }[] };
 
     expect(persisted.routes[0]?.attributionGap?.reason).toBe("snapshot-unreadable");
+  });
+});
+
+describe("aggregateRepetitions", () => {
+  const measuredRoute = (verdict: TrendVerdict, growthPerCycle: number): RouteReport => {
+    const report = makeRunReport();
+    const route = report.routes[1];
+    if (route?.status !== "measured") throw new Error("fixture broken");
+    return {
+      ...route,
+      requestsPerCycle: 1000,
+      trend: { ...route.trend, verdict, growthPerCycle },
+      confidence: { level: "high", warnings: [] },
+    };
+  };
+
+  it("keeps the verdict when every repetition agrees", () => {
+    const aggregate = aggregateRepetitions([
+      measuredRoute("leak", 2 * MB),
+      measuredRoute("leak", 3 * MB),
+    ]);
+    if (aggregate.status !== "measured") throw new Error("expected a measured route");
+    expect(aggregate.trend.verdict).toBe("leak");
+    expect(aggregate.confidence.supersededVerdict).toBeUndefined();
+    expect(aggregate.repetitions).toEqual([
+      { verdict: "leak", growthPer1000Requests: 2 * MB },
+      { verdict: "leak", growthPer1000Requests: 3 * MB },
+    ]);
+  });
+
+  // Two runs of one build disagreeing is the finding, not an average to take:
+  // vercel/next.js#84648 gave 602, 826 and 875 MB and then 39 MB on a fourth.
+  it("supersedes a disagreement with inconclusive and says so", () => {
+    const aggregate = aggregateRepetitions([
+      measuredRoute("leak", 2 * MB),
+      measuredRoute("stable", 0.01 * MB),
+    ]);
+    if (aggregate.status !== "measured") throw new Error("expected a measured route");
+    expect(aggregate.confidence.supersededVerdict).toBe("inconclusive");
+    expect(aggregate.confidence.level).toBe("low");
+    expect(aggregate.confidence.warnings.map((warning) => warning.code)).toContain(
+      "repetitions-disagree"
+    );
+  });
+
+  it("withholds an issue draft when repetitions disagree", () => {
+    const aggregate = aggregateRepetitions([
+      measuredRoute("leak", 2 * MB),
+      measuredRoute("stable", 0.01 * MB),
+    ]);
+    if (aggregate.status !== "measured") throw new Error("expected a measured route");
+    expect(warrantsIssueDraft(aggregate)).toBe(false);
+  });
+
+  // A repetition that failed is not a disagreement to average away.
+  it("returns the failure when one repetition did not measure", () => {
+    const failed: RouteReport = { route: "/x", status: "failed", reason: "port race lost" };
+    const aggregate = aggregateRepetitions([measuredRoute("leak", 2 * MB), failed]);
+    expect(aggregate.status).toBe("failed");
+  });
+});
+
+describe("repeat runs the whole measurement again", () => {
+  it("measures a route once per repetition and records each result", async () => {
+    // The loop itself, not the aggregation: a `--repeat` that quietly measured
+    // once and copied the result would pass every aggregation test above.
+    const appDir = await makeAppDir({ "/page": "app/page.js" });
+    // `ritualResult` derives its verdict from the route name, so each
+    // repetition's trend is set explicitly here.
+    const verdicts = ["leak", "leak", "stable"] as const;
+    let call = 0;
+    const report = await runMeasurement(
+      { appDir, bootstrapPath: "/fake/bootstrap.js", repeat: 3 },
+      {
+        ...makeDeps([]),
+        ritual: async (options) => {
+          const verdict = verdicts[call] ?? "leak";
+          call += 1;
+          const base = ritualResult(options.route, [29 * MB, 31 * MB, 33 * MB, 35 * MB]);
+          return {
+            ...base,
+            trend: {
+              verdict,
+              growthPerCycle: verdict === "leak" ? 2.5 * MB : 0.1 * MB,
+              deltas: [],
+            },
+          };
+        },
+      }
+    );
+
+    const route = report.routes[0];
+    if (route?.status !== "measured") throw new Error("expected a measured route");
+    expect(call).toBe(3);
+    expect(route.repetitions?.map((entry) => entry.verdict)).toEqual(["leak", "leak", "stable"]);
+    // Two leaks and a flat run: the disagreement is what gets reported.
+    expect(route.confidence.supersededVerdict).toBe("inconclusive");
+  });
+
+  it("leaves the report untouched when repeat is 1", async () => {
+    const appDir = await makeAppDir({ "/page": "app/page.js" });
+    let call = 0;
+    const report = await runMeasurement(
+      { appDir, bootstrapPath: "/fake/bootstrap.js", repeat: 1 },
+      {
+        ...makeDeps([]),
+        ritual: async (options) => {
+          call += 1;
+          return ritualResult(options.route, [29 * MB, 31 * MB, 33 * MB, 35 * MB]);
+        },
+      }
+    );
+    const route = report.routes[0];
+    if (route?.status !== "measured") throw new Error("expected a measured route");
+    expect(call).toBe(1);
+    expect(route.repetitions).toBeUndefined();
   });
 });

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -43,6 +43,13 @@ import { validateTarget, type ValidatedTarget } from "./target.js";
 import { planRevalidation, revalidateSecondsFor } from "./isr.js";
 import { minGrowthFor, type TrendResult, type TrendVerdict } from "./trend.js";
 
+/** What one repetition of a route concluded, for disclosing the spread. */
+export type RepetitionSummary = {
+  verdict: TrendVerdict;
+  /** Growth normalized by traffic, so repetitions stay comparable. */
+  growthPer1000Requests: number;
+};
+
 export type RouteReport =
   | { route: string; status: "skipped"; reason: string }
   | { route: string; status: "failed"; reason: string }
@@ -104,6 +111,12 @@ export type RouteReport =
       unreclaimedTrend: TrendResult;
       /** Requests each cycle served — what the growth rates normalize by. */
       requestsPerCycle: number;
+      /**
+       * One entry per repetition when `repeat` was greater than 1, in the
+       * order they ran. Absent for a single measurement, so `run.json` keeps
+       * its existing shape unless repetition was asked for.
+       */
+      repetitions?: RepetitionSummary[];
       /**
        * The early-disconnect regime, when the route asked for one. Recorded
        * because a curve measured with cuts landing mid-stream and one measured
@@ -243,6 +256,13 @@ export type RunOptions = {
    * call it. Default true: the run should answer the question it was asked.
    */
   resolveInconclusive?: boolean;
+  /**
+   * How many times to measure each route, each from a fresh server. Default 1.
+   *
+   * Distinct from `cycles`, which watches a single process for longer. The
+   * variance that makes a number unpublishable is between processes.
+   */
+  repeat?: number;
   /**
    * Growth the self-check measured on its planted leak, when one ran before
    * this measurement. Its presence is what lets the report say a `stable`
@@ -447,7 +467,7 @@ async function measureRoute(
   route: DiscoveredRoute,
   requestPath: string,
   index: number,
-  pass: { cycles: number; dirSuffix: string } | undefined = undefined
+  pass: { cycles?: number; dirSuffix: string } | undefined = undefined
 ): Promise<RouteReport> {
   const { deps, options, target, workDir, routeConfig, registry, nextVersion, progress } = context;
   // An ISR route serves its cache unless the request carries the build's own
@@ -477,7 +497,7 @@ async function measureRoute(
     ...(options.warmupRequests !== undefined && { warmupRequests: options.warmupRequests }),
     ...(options.loadRequests !== undefined && { loadRequests: options.loadRequests }),
     ...(options.connections !== undefined && { connections: options.connections }),
-    ...(pass !== undefined
+    ...(pass?.cycles !== undefined
       ? { cycles: pass.cycles }
       : options.cycles !== undefined && { cycles: options.cycles }),
     ...(options.idleMs !== undefined && { idleMs: options.idleMs }),
@@ -550,7 +570,7 @@ async function measureRoute(
     route: route.path,
     status: "measured",
     requestPath,
-    ...(pass !== undefined && { resolvedWithCycles: pass.cycles }),
+    ...(pass?.cycles !== undefined && { resolvedWithCycles: pass.cycles }),
     samples: result.samples,
     memorySamples: result.memorySamples,
     peaks: result.peaks,
@@ -646,7 +666,7 @@ async function routeReportFor(
     progress(`not measuring ${label}: ${plan.reason}`);
     return { route: route.path, status: "not-exercised", reason: plan.reason };
   }
-  return measureWithResolution(context, route, requestPath, index, label);
+  return measureRepeatedly(context, route, requestPath, index, label);
 }
 
 /**
@@ -675,18 +695,125 @@ function reasonToResolve(verdict: TrendVerdict): string | null {
 }
 
 /** Measures a route, and goes back for a longer look when the verdict earns one. */
-async function measureWithResolution(
+/**
+ * Measures a route `repeat` times, each from its own server, and judges it on
+ * all of them.
+ *
+ * `resolveInconclusive` already re-measures with more cycles, but extra cycles
+ * run inside the same process, so anything that varies with process startup is
+ * held fixed across every one of them. The spreads that make a number
+ * unpublishable are between processes: three runs of one build on
+ * vercel/next.js#84648 peaked at 602, 826 and 875 MB, and a fourth was flat at
+ * 39 MB.
+ *
+ * Each repetition runs the whole per-route measurement, its own inner
+ * re-measurement included. Suppressing that would mean the repetitions are not
+ * measuring what a normal run measures, so their agreement would say nothing
+ * about a normal run.
+ */
+async function measureRepeatedly(
   context: MeasurementContext,
   route: DiscoveredRoute,
   requestPath: string,
   index: number,
   label: string
 ): Promise<RouteReport> {
+  const repeat = context.options.repeat ?? 1;
+  if (repeat <= 1) {
+    return measureWithResolution(context, route, requestPath, index, label);
+  }
+
+  const passes: RouteReport[] = [];
+  for (let attempt = 1; attempt <= repeat; attempt += 1) {
+    context.progress(`repetition ${attempt}/${repeat} of ${label}`);
+    passes.push(
+      await measureWithResolution(context, route, requestPath, index, label, `-rep${attempt}`)
+    );
+    // A Ctrl+C mid-way keeps what has been measured rather than discarding it;
+    // the aggregate then judges the repetitions that actually ran.
+    if (context.options.signal?.aborted === true) {
+      break;
+    }
+  }
+  return aggregateRepetitions(passes);
+}
+
+/**
+ * Combines repeated measurements of one route into the verdict it earned.
+ *
+ * Unanimity or nothing. Taking the most severe would let one noisy repetition
+ * in five accuse a healthy route, and a false accusation is the expensive
+ * error; taking the majority would discard exactly the disagreement the
+ * repetitions were run to find. When they disagree the honest report is that
+ * the measurement did not settle, which is what `inconclusive` means and what
+ * already routes to re-measurement and away from issue drafts.
+ */
+export function aggregateRepetitions(passes: readonly RouteReport[]): RouteReport {
+  const first = passes[0];
+  if (first === undefined) {
+    return { route: "", status: "failed", reason: "no repetition produced a result" };
+  }
+  const measured = passes.filter((pass) => pass.status === "measured");
+  // A repetition that failed or died of heap is not a disagreement to average
+  // away — the first non-measured outcome is the finding, and it is returned
+  // as it stands.
+  if (measured.length !== passes.length || measured.length === 0) {
+    return passes.find((pass) => pass.status !== "measured") ?? first;
+  }
+
+  const repetitions: RepetitionSummary[] = measured.map((pass) => ({
+    verdict: pass.trend.verdict,
+    growthPer1000Requests: (pass.trend.growthPerCycle / pass.requestsPerCycle) * 1000,
+  }));
+  const verdicts = [...new Set(repetitions.map((entry) => entry.verdict))];
+  const winner = measured[0];
+  if (winner === undefined) {
+    return first;
+  }
+  if (verdicts.length === 1) {
+    return { ...winner, repetitions };
+  }
+
+  const observed = verdicts.join(", ");
+  return {
+    ...winner,
+    repetitions,
+    confidence: {
+      ...winner.confidence,
+      level: "low",
+      warnings: [
+        ...winner.confidence.warnings,
+        {
+          code: "repetitions-disagree",
+          detail:
+            `${repetitions.length} repetitions of this route disagreed (${observed}) — ` +
+            `the measurement did not settle, so no single verdict is reported`,
+        },
+      ],
+      supersededVerdict: "inconclusive",
+    },
+  };
+}
+
+async function measureWithResolution(
+  context: MeasurementContext,
+  route: DiscoveredRoute,
+  requestPath: string,
+  index: number,
+  label: string,
+  repetitionSuffix = ""
+): Promise<RouteReport> {
   const { progress } = context;
   try {
     const asPath = requestPath === route.path ? "" : ` as ${requestPath}`;
     progress(`measuring ${label}${asPath}`);
-    const first = await measureRoute(context, route, requestPath, index);
+    const first = await measureRoute(
+      context,
+      route,
+      requestPath,
+      index,
+      repetitionSuffix === "" ? undefined : { dirSuffix: repetitionSuffix }
+    );
     const reason = first.status === "measured" ? reasonToResolve(effectiveVerdict(first)) : null;
     if (first.status !== "measured" || context.options.resolveInconclusive === false || reason === null) {
       return first;
@@ -702,7 +829,7 @@ async function measureWithResolution(
     try {
       return await measureRoute(context, route, requestPath, index, {
         cycles,
-        dirSuffix: "-resolve",
+        dirSuffix: `${repetitionSuffix}-resolve`,
       });
     } catch (cause) {
       // The second pass is a bonus, not a bet: losing it (port race lost

--- a/src/trend.test.ts
+++ b/src/trend.test.ts
@@ -367,6 +367,67 @@ describe("saturating growth", () => {
   });
 });
 
+describe("saturation reached at the tail", () => {
+  // Field series, Next 16.3.4 on 2026-09-03: a `use cache` route at 3000
+  // requests per cycle, gate 262 144 B. Deltas
+  // [598048, 677536, 465744, 435992, 892616, 447464, 252504]. The closing
+  // cycle is 96% of the gate, so `allGrow` was false, saturation was never
+  // evaluated, and stepwise detection claimed it — a curve that flattens has
+  // no drawdown. The verdict was `leak` on a route whose growth had stopped
+  // reaching the leak rate. A control fixture with `'use cache'` removed
+  // entirely reported the same +0.17 MB/1000 req, so this was never even
+  // cache residency.
+  const FIELD_SAMPLES = [
+    30907912, 32686936, 33284984, 33962520, 34428264, 34864256, 35756872, 36204336, 36456840,
+  ];
+
+  it("calls the field series saturating once the tail is admissible", () => {
+    const result = classifyTrend(FIELD_SAMPLES, { minGrowthPerCycle: minGrowthFor(3000) });
+    expect(result.deltas).toEqual([598048, 677536, 465744, 435992, 892616, 447464, 252504]);
+    expect(result.verdict).toBe("saturating");
+  });
+
+  it("bends despite stepping up twice on the way down", () => {
+    // The same shape, stated plainly: monotonicity is not required, arrival
+    // and direction are.
+    const samples = [28 * MB, 30 * MB, 38 * MB, 45 * MB, 49 * MB, 58 * MB, 61 * MB, 62 * MB];
+    const result = classifyTrend(samples);
+    expect(result.deltas).toEqual([8 * MB, 7 * MB, 4 * MB, 9 * MB, 3 * MB, 1 * MB]);
+    expect(result.verdict).toBe("saturating");
+  });
+
+  it("keeps a halt a leak even when the rest of the curve bends", () => {
+    // Identical to the bend above except the closing cycle is 0: a wall, not
+    // a curve, and stepwise detection keeps it.
+    const samples = [28 * MB, 30 * MB, 38 * MB, 45 * MB, 49 * MB, 58 * MB, 61 * MB, 61 * MB];
+    const result = classifyTrend(samples);
+    expect(result.deltas).toEqual([8 * MB, 7 * MB, 4 * MB, 9 * MB, 3 * MB, 0]);
+    expect(result.verdict).toBe("leak");
+  });
+
+  it("refuses a series that never grew at the leak rate to begin with", () => {
+    // Deltas well under the gate throughout: nothing to decelerate from, and
+    // small consistent drift is measurement noise, not a store filling up.
+    const samples = [
+      10 * MB,
+      11 * MB,
+      11 * MB + 60 * KIB,
+      11 * MB + 100 * KIB,
+      11 * MB + 120 * KIB,
+    ];
+    expect(classifyTrend(samples).verdict).not.toBe("saturating");
+  });
+
+  it("refuses a decline that arrives nowhere", () => {
+    // Later cycles below earlier ones, but the closing cycle is still 75% of
+    // the opening one: running slower, not running out.
+    const samples = [28 * MB, 30 * MB, 38 * MB, 45.5 * MB, 52.5 * MB, 58.5 * MB];
+    const result = classifyTrend(samples);
+    expect(result.deltas).toEqual([8 * MB, 7.5 * MB, 7 * MB, 6 * MB]);
+    expect(result.verdict).toBe("leak");
+  });
+});
+
 describe("cache-driven context", () => {
   it("records the context without moving the verdict", () => {
     // Same series, both ways round: the flag is disclosure, not a threshold.

--- a/src/trend.ts
+++ b/src/trend.ts
@@ -173,26 +173,62 @@ function isStepwiseGrowth(
  * a `use cache` route that was storing exactly what it was asked to store,
  * against +88 MB/1000 for the same route once the payload was removed.
  *
- * Only reachable from the `allGrow` branch, so it cannot take cases from
- * stepwise detection: a staircase has cycles below the gate by definition.
+ * Three conditions, and each one earns its place:
+ *
+ * - **Every delta strictly positive.** A store that runs out stores *less*; it
+ *   does not stop. A series reaching zero has hit a wall, which is a staircase
+ *   and belongs to stepwise detection — `[8, 3, 0] MB` and the #95094 climb
+ *   both end that way and both are leaks.
+ * - **The opening cycle clears the gate.** Growth that never reached the leak
+ *   rate has nothing to decelerate from.
+ * - **It arrives somewhere, and it is heading there.** The final delta at most
+ *   half the first, *and* the later cycles averaging below the earlier ones.
+ *   Arrival alone would admit a series that spikes and drops on its last
+ *   cycle; direction alone would admit a decline that never gets anywhere.
+ *
+ * What is deliberately *not* required is that each delta be smaller than the
+ * one before it. Post-GC deltas do not descend in order — measured on Next
+ * 16.3.4 on 2026-09-03, a `use cache` route bent from 598 KB to 252 KB per
+ * cycle while stepping up twice on the way. Demanding monotonicity rejected
+ * that curve, and the tail dropping under the gate meant the test was never
+ * reached in the first place.
  */
-function isSaturating(deltas: readonly number[]): boolean {
+function isSaturating(deltas: readonly number[], minGrowth: number): boolean {
   if (deltas.length < SATURATION_MIN_CYCLES) {
     return false;
   }
   const first = deltas[0];
   const last = deltas[deltas.length - 1];
-  if (first === undefined || last === undefined || first <= 0) {
+  if (first === undefined || last === undefined || first < minGrowth) {
     return false;
   }
-  for (let i = 1; i < deltas.length; i += 1) {
-    const current = deltas[i];
-    const previous = deltas[i - 1];
-    if (current === undefined || previous === undefined || current >= previous) {
-      return false;
-    }
+  if (!deltas.every((delta) => delta > 0)) {
+    return false;
   }
-  return last <= first * SATURATION_MAX_FINAL_RATIO;
+  if (last > first * SATURATION_MAX_FINAL_RATIO) {
+    return false;
+  }
+  return isHeadingDown(deltas);
+}
+
+/**
+ * Whether the later cycles sit below the earlier ones.
+ *
+ * The split rounds the first half down, so the shortest admissible series
+ * (three deltas) compares one against two. That is coarse on purpose: it is
+ * paired with the arrival test, which is what stops a gentle wander from
+ * reading as deceleration.
+ */
+function isHeadingDown(deltas: readonly number[]): boolean {
+  const midpoint = Math.floor(deltas.length / 2);
+  const head = deltas.slice(0, midpoint);
+  const tail = deltas.slice(midpoint);
+  if (head.length === 0 || tail.length === 0) {
+    return false;
+  }
+  const mean = (values: readonly number[]): number =>
+    values.reduce((sum, value) => sum + value, 0) / values.length;
+  return mean(tail) < mean(head);
 }
 
 /**
@@ -250,10 +286,16 @@ function classifyShape(samples: readonly number[], options: TrendOptions): Trend
   //                  Also where a large oscillating series lands: the
   //                  acquittal is withdrawn, but a magnitude is not a shape
   //                  and will not carry an accusation.
+  // Saturation is judged before `allGrow` and before stepwise growth, because
+  // a store that has finished filling produces closing cycles *below* the
+  // gate. Gating this on `allGrow` made the verdict unreachable at exactly the
+  // point where the shape is clearest, and the series then fell to stepwise
+  // detection, which claims it: a curve that flattens hands nothing back, so
+  // its drawdown is zero. Measured on Next 16.3.4, 2026-09-03.
+  if (isSaturating(deltas, minGrowth)) {
+    return { verdict: "saturating", growthPerCycle: mean, deltas, source: "heap" };
+  }
   if (allGrow) {
-    if (isSaturating(deltas)) {
-      return { verdict: "saturating", growthPerCycle: mean, deltas, source: "heap" };
-    }
     return { verdict: "leak", growthPerCycle: mean, deltas, source: "heap" };
   }
   if (isStepwiseGrowth(samples, deltas, growingCycles, mean, minGrowth)) {


### PR DESCRIPTION
Two defects the field found this week, both about a verdict claiming more than the samples support.

## 1. `saturating` was unreachable at the point saturation is clearest

`isSaturating` was only called from the `allGrow` branch, which requires every post-warm-up delta to clear the growth gate. A store that finishes filling produces closing cycles *below* the gate, so the branch that would name the shape was never entered, and the series fell through to `isStepwiseGrowth` — which claims it, because a curve that flattens hands nothing back and therefore has zero drawdown.

Measured on Next 16.3.4 on 2026-09-03, a `'use cache'` route at 3000 requests per cycle:

```
deltas          : [598048, 677536, 465744, 435992, 892616, 447464, 252504]
cada delta>=gate: [true, true, true, true, true, true, false]
allGrow         : false        <- last delta is 96% of the gate
ratio final     : 0.422        <- already inside SATURATION_MAX_FINAL_RATIO
VERDICT         : leak
```

A control fixture with `'use cache'` removed entirely reported the same +0.17 MB/1000 req, so the growth was not even cache residency — the tool had committed to `leak` on evidence whose own tail had stopped growing.

A second defect sat behind it: `isSaturating` demanded every delta be smaller than the one before. Post-GC deltas do not descend in order; the series above bends downward while stepping up twice.

**Fix:** saturation is judged before `allGrow` and before stepwise growth, with its own admission rule. Per-step monotonicity is replaced by arrival (unchanged final-ratio test) plus direction (later cycles averaging below earlier ones).

**What does not move:** every delta must still be strictly positive. A series that halts is a wall, not a curve, and stepwise detection keeps it — `[8, 3, 0] MB` and the #95094 staircase both hold their `leak`. That line was drawn deliberately by `tell-cache-from-leak` and this change respects it.

## 2. `--repeat N`

A verdict came from one measurement, and one measurement of this quantity is not repeatable. From this week, on unmodified public repros:

- three runs of one Next build peaked at 602, 826 and 875 MB retained; a fourth was flat at 39 MB
- a reporter's own retention probe spanned 6.5–16.0 per render on identical runs
- at-limit counts on identical container runs: 2 660 029 and 3 794 422

`resolveCycles` already re-measures with more cycles, but extra cycles run inside one process, so everything that varies with process startup is held fixed. That is where the spread lives.

`--repeat N` measures each route N times from a fresh server. Unanimous repetitions keep their verdict; disagreement supersedes it with `inconclusive`, records which verdicts came up, and withholds the issue draft. Taking the most severe would let one noisy repetition accuse a healthy route; taking the majority would discard the disagreement the repetitions were run to find.

The spread is printed even when the verdicts agree — equal verdicts over unequal magnitudes is the case this exists for.

## Verification

End-to-end against the 2026-09-03 fixture:

```
~ /p/[id]  saturating  (+0.17 MB/1000 req)  heap 29.2 → … → 34.7 MB  (resolved at 8 cycles)
```

And with `--repeat 3` on the same fixture:

```
? /p/[id]  inconclusive  (+0.17 MB/1000 req)
      across 3 repetitions: +0.17 to +0.17 MB/1000 req — they disagreed (leak, saturating)
      ⚠ low confidence: 3 repetitions of this route disagreed
```

Three repetitions of one fixture, identical growth rate, two different verdicts. Before this, one of them would have been reported as the answer.

`pnpm typecheck` clean, `pnpm test` 767 passing (42 files).

Default is `--repeat 1` on the current code path, so `run.json` keeps its shape unless repetition is asked for.
