### PR TITLE
test(control-client): model the snapshot writer as an append, not a rewrite

### DIFF
--- a/src/control-client.test.ts
+++ b/src/control-client.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdtemp, rm, writeFile } from "node:fs/promises";
 import http from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -148,6 +148,28 @@ describe("snapshot waits judged by progress on disk", () => {
     }
   });
 
+  /**
+   * A writer that only ever makes the file bigger, one append at a time.
+   *
+   * Serialized on purpose: overlapping appends are what let the poll observe a
+   * size that is not monotonic, and the whole point of the file-watching path
+   * is that growth is the signal.
+   */
+  function appendingWriter(file: string): () => Promise<void> {
+    let writing = false;
+    return async () => {
+      if (writing) {
+        return;
+      }
+      writing = true;
+      try {
+        await appendFile(file, Buffer.alloc(1024));
+      } finally {
+        writing = false;
+      }
+    };
+  }
+
   async function tempDir(): Promise<string> {
     dir = await mkdtemp(path.join(tmpdir(), "next-leak-watch-"));
     return dir;
@@ -169,11 +191,19 @@ describe("snapshot waits judged by progress on disk", () => {
         );
       }, 400);
     });
-    let bytes = 0;
-    const growing = setInterval(() => {
-      bytes += 1024;
-      void writeFile(file, Buffer.alloc(bytes));
-    }, 20);
+    // A real snapshot is appended to, never rewritten. `writeFile` truncates to
+    // zero on every tick, and the poll reads that zero: measured on this
+    // pattern, 11 of 138 reads came back 0 and 11 went backwards. Since the
+    // watcher only refreshes its stall clock when the file *grows*, a run of
+    // those reads inside one stall window is enough to declare a healthy child
+    // wedged — which is how this test failed on CI once.
+    const grow = appendingWriter(file);
+    // Growing before the wait starts means the first poll reads a real size
+    // rather than a missing file, and appending every 10 ms leaves the widest
+    // observed gap between growths (30 ms, measured) well inside the 100 ms
+    // stall window without relaxing the window itself.
+    await grow();
+    const growing = setInterval(() => void grow(), 10);
     try {
       const answer = await requestWatchingFile(port, "/snapshot?name=after", 60_000, {
         file,
@@ -210,11 +240,8 @@ describe("snapshot waits judged by progress on disk", () => {
     const port = await listen(() => {
       // Never answers; the file below never stops growing either.
     });
-    let bytes = 0;
-    const growing = setInterval(() => {
-      bytes += 1024;
-      void writeFile(file, Buffer.alloc(bytes));
-    }, 10);
+    const grow = appendingWriter(file);
+    const growing = setInterval(() => void grow(), 10);
     try {
       await expect(
         requestWatchingFile(port, "/snapshot?name=after", 60_000, {


### PR DESCRIPTION
`keeps waiting while the file is still growing, past the stall window` failed once on CI (2026-09-03) under `verify (24)`, while `verify (22)` passed on the same commit and the job passed on rerun:

```
ControlError: control channel /snapshot?name=after on port 46489 wrote nothing for 0s (0.0 MB on disk) — the measured process is wedged
 ❯ giveUp src/control-client.ts:159:16
 ❯ check src/control-client.ts:202:13
```

## The fixture was modelling the wrong writer

The file-watching tests grew their fixture on a timer with `writeFile(file, Buffer.alloc(bytes))`, unawaited. That truncates to zero on every tick, and the production poll reads the file with `stat`. Measured on the old pattern — 1.5 s, appending on a 20 ms timer, polling every 10 ms as production does:

```
lecturas            : 138
tamano 0            : 11
retrocesos          : 11
primeras 20         : [null,null,1024,1024,2048,0,3072,3072,4096,...]
```

That is the whole failure. The watcher refreshes its stall clock only when the file **grows**, so a run of truncated reads inside one 100 ms stall window is enough to declare a healthy child wedged — and `0.0 MB on disk` in the CI message is exactly the truncated read being latched as `lastSize`.

A real V8 snapshot is appended to, never rewritten. The fixture now:

- appends 1 KiB at a time instead of rewriting the whole file,
- serializes its appends, so overlapping writes cannot make the observed size move backwards,
- grows once before the wait begins, so the first poll reads a real size rather than a missing file.

Measured on the new pattern:

```
lecturas              : 141
tamano 0              : 0
retrocesos            : 0
fichero inexistente   : 0
mayor hueco sin crecer: 30 ms   (stall window is 100 ms)
```

Passes 5/5 with twelve CPU-burning processes running alongside.

## What this deliberately does not do

**No production change.** Growth-only stall detection is correct for the writer it actually watches. Worth recording, though: the consequence is that any writer that truncated or rewrote its output would be declared wedged. That is not how snapshots are written today — flagging it in case that ever changes, not proposing a change here.

**No fake timers.** This test combines real disk I/O with a real HTTP socket; faking the clock means interleaving timer advances with event-loop yields so that I/O can progress, which is its own well-known source of flakiness. That would trade a measured fragility for an unmeasured construction.

**No relaxed timings.** The 100 ms stall window and the 400 ms server delay are unchanged. The writer appends every 10 ms rather than 20 ms, which widens the margin without touching any assertion.

`pnpm typecheck` clean, `pnpm test` 767 passing (42 files).
