### PR TITLE
fix: measure a monorepo build where it is, and say why it never listened (thanks @ucarno)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Every report prints the gate it used.
 | `--idle <seconds>` | 30 | **Maximum** wait before each sample; the run continues as soon as the heap settles |
 | `--warmup <n>` | 200 | Requests before the baseline snapshot. Lower it on apps that cache per request: warm-up fills those caches and the baseline then measures the warm-up, not the app. The run says so when it happens |
 | `--max-old-space <mb>` | 512 | Heap cap of each measured process. Raise it for apps whose legitimate working set is larger, or they die under measurement |
+| `--ready-timeout <seconds>` | 60 | How long each measured process gets to start listening. Raise it for apps that boot slowly. A process that never listens reports whatever it wrote to stderr while trying |
 | `--quick` | off | Fast preset (2000 requests × 4 cycles, 8s idle) — the exact profile the real-app validation ran with. Same cycle count as the default; what it trades away is traffic per cycle, so it sits on the noise floor and is less sensitive to slow leaks. Explicit flags override it |
 | `--no-resolve` | off | Skip the second pass on inconclusive routes |
 | `--self-check` | off | Measure a planted leak first to prove the harness works here. Costs one route's worth of time; a run that cannot detect 8 KB per request produces verdicts worth nothing |
@@ -409,6 +410,17 @@ through the build's source maps.
 
 
 - **Supported (default command):** App Router · `output: "standalone"` · Node ≥ 22 · Linux/macOS. Pages Router, non-standalone, and Windows are rejected with a clear message.
+- **Monorepos work unchanged.** A workspace build does not put `server.js` at
+  the root of `.next/standalone`: Next keeps the app's path relative to the
+  workspace root, so an app in `client/` ships its server at
+  `.next/standalone/client/server.js` with `node_modules` hoisted above it.
+  Point the tool at the app directory as usual — it looks there too. Do not
+  flatten that tree by hand: on a pnpm workspace the moved `server.js` cannot
+  resolve `next` any more, because what sits in `standalone/<app>/node_modules`
+  are relative symlinks into `../../node_modules/.pnpm/`, and a level up they
+  point outside the tree. An npm workspace survives the move — it puts no
+  `node_modules` beside the app at all — which is why the same build can serve
+  by hand and still be unmeasurable.
 - **Sample values can vary per request.** `"slug": "post-{n}"` gives every
   request its own URL — the shape of bot traffic and of a cache that never
   repeats a key. `"slug": "post-{n%200}"` cycles through exactly 200 distinct

--- a/src/__fixtures__/hangs-without-listening.js
+++ b/src/__fixtures__/hangs-without-listening.js
@@ -1,0 +1,7 @@
+// A server that fails during startup and does not die: it writes the reason to
+// stderr and keeps the event loop alive without ever opening the app port.
+// Real apps reach this state when boot awaits something that never resolves —
+// and the launcher must hand over what the process said, not just the port it
+// never bound.
+process.stderr.write("Error: DATABASE_URL is not set\n");
+setInterval(() => {}, 1000);

--- a/src/cli-args.test.ts
+++ b/src/cli-args.test.ts
@@ -31,6 +31,7 @@ describe("parseCliArgs", () => {
         idleSeconds: null,
         warmupRequests: null,
         maxOldSpaceMb: null,
+        readyTimeoutSeconds: null,
         quick: false,
         noResolve: false,
         selfCheck: false,
@@ -45,7 +46,8 @@ describe("parseCliArgs", () => {
   it("parses every flag", () => {
     const parsed = parseCliArgs([
       "app", "--routes", "/api,/dashboard", "--cycles", "6", "--repeat", "3", "--requests", "1000",
-      "--connections", "20", "--idle", "8", "--warmup", "50", "--max-old-space", "2048", "--quick",
+      "--connections", "20", "--idle", "8", "--warmup", "50", "--max-old-space", "2048",
+      "--ready-timeout", "120", "--quick",
       "--diff-all", "--no-resolve", "--self-check", "--write-config", "--output", "/tmp/out",
     ]);
     if (parsed.kind !== "run") {
@@ -61,6 +63,7 @@ describe("parseCliArgs", () => {
       idleSeconds: 8,
       warmupRequests: 50,
       maxOldSpaceMb: 2048,
+      readyTimeoutSeconds: 120,
       quick: true,
       noResolve: true,
       selfCheck: true,

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -16,6 +16,8 @@ export type CliRunOptions = {
   idleSeconds: number | null;
   warmupRequests: number | null;
   maxOldSpaceMb: number | null;
+  /** Seconds each measured process gets to boot before the route is failed. */
+  readyTimeoutSeconds: number | null;
   quick: boolean;
   noResolve: boolean;
   selfCheck: boolean;
@@ -56,6 +58,7 @@ const RUN_ONLY_FLAGS: ReadonlyArray<[keyof CliRunOptions, string]> = [
   ["idleSeconds", "--idle"],
   ["warmupRequests", "--warmup"],
   ["maxOldSpaceMb", "--max-old-space"],
+  ["readyTimeoutSeconds", "--ready-timeout"],
   ["quick", "--quick"],
   ["noResolve", "--no-resolve"],
   ["selfCheck", "--self-check"],
@@ -112,6 +115,12 @@ const FLAGS: FlagSpec[] = [
     value: "int",
     argName: "<mb>",
     help: "Heap cap of each measured process (default 512) — raise it for apps whose working set is larger",
+  },
+  {
+    flag: "--ready-timeout",
+    value: "int",
+    argName: "<seconds>",
+    help: "Seconds each measured process gets to start listening (default 60) — raise it for slow-booting apps",
   },
   {
     flag: "--quick",
@@ -188,6 +197,7 @@ const LIMITS: Record<string, number | undefined> = {
   "--idle": 3_600,
   "--warmup": 1_000_000,
   "--max-old-space": 65_536,
+  "--ready-timeout": 600,
 };
 
 /**
@@ -243,6 +253,7 @@ function applyNumericFlag(flag: string, value: string, options: CliRunOptions): 
   if (flag === "--idle") options.idleSeconds = parsed;
   if (flag === "--warmup") options.warmupRequests = parsed;
   if (flag === "--max-old-space") options.maxOldSpaceMb = parsed;
+  if (flag === "--ready-timeout") options.readyTimeoutSeconds = parsed;
   return FLAG_OK;
 }
 
@@ -257,6 +268,7 @@ function applyFlag(spec: FlagSpec, value: string, options: CliRunOptions): FlagO
     case "--idle":
     case "--warmup":
     case "--max-old-space":
+    case "--ready-timeout":
       return applyNumericFlag(spec.flag, value, options);
     case "--quick":
       options.quick = true;
@@ -340,6 +352,7 @@ export function parseCliArgs(argv: string[]): ParsedCli {
     idleSeconds: null,
     warmupRequests: null,
     maxOldSpaceMb: null,
+    readyTimeoutSeconds: null,
     quick: false,
     noResolve: false,
     selfCheck: false,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -254,6 +254,9 @@ async function main(): Promise<void> {
     ...(options.idleSeconds !== null && { idleMs: options.idleSeconds * 1000 }),
     ...(options.warmupRequests !== null && { warmupRequests: options.warmupRequests }),
     ...(options.maxOldSpaceMb !== null && { maxOldSpaceMb: options.maxOldSpaceMb }),
+    ...(options.readyTimeoutSeconds !== null && {
+      readyTimeoutMs: options.readyTimeoutSeconds * 1000,
+    }),
     ...(options.diffAll && { diffAll: true }),
     ...(options.noResolve && { resolveInconclusive: false }),
     ...(options.output !== null && { outputDir: options.output }),

--- a/src/launcher-messages.test.ts
+++ b/src/launcher-messages.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { explainRuntimeFailure, explainStartupFailure } from "./launcher.js";
+import { appNeverListened, explainRuntimeFailure, explainStartupFailure } from "./launcher.js";
 
 // Pure message functions, split from launcher.test.ts (which boots real
 // processes and is excluded from mutation runs) so mutation can judge the
@@ -81,5 +81,24 @@ describe("explainRuntimeFailure", () => {
     // The window handed to the explainer must still contain the FATAL line.
     const window = `${dump.slice(0, 4096)}\n[...]\n${dump.slice(-4096)}`;
     expect(explainRuntimeFailure(window, 512)).toContain("ran out of heap");
+  });
+});
+
+// The app port staying shut is the one failure the launcher used to describe
+// by naming the port and nothing else — while holding the process's own
+// explanation in a buffer it only printed if the process had died (#71).
+describe("appNeverListened", () => {
+  it("hands over what the process wrote while starting", () => {
+    const message = appNeverListened("127.0.0.1", 44203, 60_000, "Error: DATABASE_URL is not set\n");
+    expect(message).toContain("127.0.0.1:44203");
+    expect(message).toContain("never listened within 60s");
+    expect(message).toContain("DATABASE_URL is not set");
+  });
+
+  it("names the budget and the flag that moves it when the process said nothing", () => {
+    const message = appNeverListened("127.0.0.1", 44203, 15_000, "   \n");
+    expect(message).toContain("never listened within 15s");
+    expect(message).toContain("wrote nothing to stderr");
+    expect(message).toContain("--ready-timeout");
   });
 });

--- a/src/launcher.test.ts
+++ b/src/launcher.test.ts
@@ -9,6 +9,9 @@ import { launchInstrumented, type LaunchedApp } from "./launcher.js";
 const rootDir = fileURLToPath(new URL("..", import.meta.url));
 const bootstrapPath = path.join(rootDir, "dist", "bootstrap.js");
 const fakeServer = fileURLToPath(new URL("./__fixtures__/fake-standalone-server.js", import.meta.url));
+const hangingServer = fileURLToPath(
+  new URL("./__fixtures__/hangs-without-listening.js", import.meta.url)
+);
 
 async function freePort(): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -33,6 +36,23 @@ afterEach(async () => {
 });
 
 describe("launchInstrumented", () => {
+  // A boot that hangs instead of dying keeps the process alive, so the exit
+  // path that prints stderr never runs. The user was left with a port number
+  // and no reason (#71); the reason was in the buffer the whole time.
+  it("reports what a hung startup wrote to stderr instead of only the port", async () => {
+    const workDir = await mkdtemp(path.join(tmpdir(), "next-leak-hang-"));
+    const port = await freePort();
+    await expect(
+      launchInstrumented({
+        serverPath: hangingServer,
+        workDir,
+        appPort: port,
+        bootstrapPath,
+        readyTimeoutMs: 1500,
+      })
+    ).rejects.toThrow(/DATABASE_URL is not set/);
+  }, 20_000);
+
   it("boots the server with a working control channel, then tears it down", async () => {
     const workDir = await mkdtemp(path.join(tmpdir(), "next-leak-launch-"));
     app = await launchInstrumented({

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -16,6 +16,19 @@ const controlFileSchema = z.object({ port: z.number(), pid: z.number() });
  */
 export const DEFAULT_MAX_OLD_SPACE_MB = 512;
 
+/**
+ * How long each startup wait gets before the route is called failed.
+ *
+ * It was 15 s, shared between waiting for the control channel and waiting for
+ * the app to listen — so a slow channel spent the app's budget too. Both
+ * numbers were also invisible: a real app that needs longer to boot than the
+ * tool was willing to wait had no way to say so, and got
+ * `timed out waiting for app` on every route (#71). 60 s is what a cold
+ * standalone bundle of a couple of thousand modules takes on a laptop with
+ * a busy disk, with room to spare; `--ready-timeout` moves it.
+ */
+export const DEFAULT_READY_TIMEOUT_MS = 60_000;
+
 export type LaunchOptions = {
   /** Absolute path to the standalone `server.js` (or any PORT/HOSTNAME-honoring server). */
   serverPath: string;
@@ -27,6 +40,10 @@ export type LaunchOptions = {
   bootstrapPath: string;
   hostname?: string;
   maxOldSpaceMb?: number;
+  /**
+   * Budget for each of the two waits below, not for the pair. Default:
+   * `DEFAULT_READY_TIMEOUT_MS`.
+   */
   readyTimeoutMs?: number;
   env?: Record<string, string>;
 };
@@ -147,11 +164,45 @@ export function explainRuntimeFailure(stderr: string, maxOldSpaceMb: number): st
   return `the measured process exited mid-run. ${explainStartupFailure(stderr)}`;
 }
 
+/**
+ * What to say when the process is alive and answering on its control channel,
+ * but never opened the app port. The old message named the port and stopped
+ * there, which reads like the tool failed to connect to something that was
+ * running. The process is up: what did not happen is the listen.
+ */
+export function appNeverListened(
+  hostname: string,
+  port: number,
+  budgetMs: number,
+  stderr: string
+): string {
+  const head =
+    `app on ${hostname}:${port} — the process started and answered on its control ` +
+    `channel, but never listened within ${Math.round(budgetMs / 1000)}s`;
+  // The app usually said why, on a stream this process has been buffering all
+  // along. It was only ever printed when the child exited, so a boot that hung
+  // instead of dying — the exact case this message covers — threw the
+  // explanation away and left the user with a port number (#71).
+  if (stderr.trim() !== "") {
+    return `${head}. It wrote this while starting:\n${stderr.trim()}`;
+  }
+  return (
+    `${head}, and wrote nothing to stderr. An app that boots slower than that ` +
+    `needs a larger budget: --ready-timeout <seconds>. Otherwise it is hanging ` +
+    `during startup — starting the same server.js by hand, with PORT set, hangs ` +
+    `the same way and can be interrupted to see where`
+  );
+}
+
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
+/**
+ * `describe` is called at the moment of the timeout, not before it: what the
+ * failure should say can depend on what the process did while being waited on.
+ */
 async function pollUntil<T>(
   deadline: number,
-  what: string,
+  describe: () => string,
   probe: () => Promise<T | undefined>,
   failed: () => string | undefined
 ): Promise<T> {
@@ -165,7 +216,7 @@ async function pollUntil<T>(
       return result;
     }
     if (Date.now() > deadline) {
-      throw new LaunchError(`timed out waiting for ${what}`);
+      throw new LaunchError(`timed out waiting for ${describe()}`);
     }
     await sleep(100);
   }
@@ -178,7 +229,7 @@ async function pollUntil<T>(
  */
 export async function launchInstrumented(options: LaunchOptions): Promise<LaunchedApp> {
   const hostname = options.hostname ?? "127.0.0.1";
-  const deadline = Date.now() + (options.readyTimeoutMs ?? 15_000);
+  const readyTimeoutMs = options.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS;
 
   const child: ChildProcess = spawn(
     process.execPath,
@@ -233,8 +284,8 @@ export async function launchInstrumented(options: LaunchOptions): Promise<Launch
 
   try {
     const controlPort = await pollUntil(
-      deadline,
-      `control channel in ${options.workDir}`,
+      Date.now() + readyTimeoutMs,
+      () => `control channel in ${options.workDir}`,
       // Several processes may announce a channel (clustered servers); accept
       // the first one that actually answers instead of trusting a filename.
       async () => {
@@ -264,9 +315,13 @@ export async function launchInstrumented(options: LaunchOptions): Promise<Launch
       failed
     );
 
+    // Its own budget, started here. The control channel comes up when the
+    // bootstrap is imported, which is before the app has loaded a single
+    // module of its own — so the time the channel took says nothing about
+    // how long the app needs, and must not be deducted from it.
     await pollUntil(
-      deadline,
-      `app on ${hostname}:${options.appPort}`,
+      Date.now() + readyTimeoutMs,
+      () => appNeverListened(hostname, options.appPort, readyTimeoutMs, stderrWindow()),
       async () => {
         try {
           await fetch(`http://${hostname}:${options.appPort}/`, { method: "HEAD" });

--- a/src/ritual.ts
+++ b/src/ritual.ts
@@ -27,6 +27,8 @@ export type RitualOptions = {
   idleMs?: number;
   /** Old-space cap for the measured process (MB). Default: 512. */
   maxOldSpaceMb?: number;
+  /** How long the process gets to start listening (ms). Default: 60_000. */
+  readyTimeoutMs?: number;
   /** Headers sent with every request during warm-up and load. */
   headers?: Record<string, string>;
   /**
@@ -366,6 +368,7 @@ export async function runRitual(
     workDir: options.workDir,
     bootstrapPath: options.bootstrapPath,
     ...(options.maxOldSpaceMb !== undefined && { maxOldSpaceMb: options.maxOldSpaceMb }),
+    ...(options.readyTimeoutMs !== undefined && { readyTimeoutMs: options.readyTimeoutMs }),
   };
   let app;
   try {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -247,6 +247,11 @@ export type RunOptions = {
   idleMs?: number;
   /** Old-space cap for each measured process (MB). Default 512. */
   maxOldSpaceMb?: number;
+  /**
+   * How long each measured process gets to start listening, in milliseconds.
+   * Default: `DEFAULT_READY_TIMEOUT_MS`.
+   */
+  readyTimeoutMs?: number;
   /** Also diff routes with a stable verdict. Default false: diffs are slow. */
   diffAll?: boolean;
   /** Only measure routes matching these templates or prefixes. */
@@ -502,6 +507,7 @@ async function measureRoute(
       : options.cycles !== undefined && { cycles: options.cycles }),
     ...(options.idleMs !== undefined && { idleMs: options.idleMs }),
     ...(options.maxOldSpaceMb !== undefined && { maxOldSpaceMb: options.maxOldSpaceMb }),
+    ...(options.readyTimeoutMs !== undefined && { readyTimeoutMs: options.readyTimeoutMs }),
     ...(headers !== undefined && { headers }),
     ...(routeConfig.abandonAfterMs !== undefined && {
       abandonAfterMs: routeConfig.abandonAfterMs,

--- a/src/target.test.ts
+++ b/src/target.test.ts
@@ -24,7 +24,42 @@ async function makeValidBuild(appDir: string): Promise<void> {
   );
 }
 
+/**
+ * A monorepo build does not put `server.js` at the root of the standalone
+ * tree: Next keeps the app's path relative to the workspace root it detected.
+ * Measured on Next 16.3.3 with a pnpm workspace whose app lives in `client/`,
+ * the server ships at `.next/standalone/client/server.js` with `node_modules`
+ * hoisted above it — and flattening that tree by hand breaks the symlinks it
+ * resolves through, so the tool has to meet the build where it is (#71).
+ */
+async function makeMonorepoBuild(appDir: string, suffix: string): Promise<void> {
+  await mkdir(path.join(appDir, ".next", "standalone", suffix), { recursive: true });
+  await mkdir(path.join(appDir, ".next", "server"), { recursive: true });
+  await writeFile(path.join(appDir, ".next", "standalone", suffix, "server.js"), "// stub\n");
+  await cp(
+    new URL("app-paths-manifest.json", FIXTURES),
+    path.join(appDir, ".next", "server", "app-paths-manifest.json")
+  );
+}
+
 describe("validateTarget", () => {
+  it("finds the standalone server under the app's own path in a monorepo", async () => {
+    const appDir = await makeAppDir();
+    await makeMonorepoBuild(appDir, path.basename(appDir));
+    const target = await validateTarget(appDir);
+    expect(target.standaloneServer).toBe(
+      path.join(appDir, ".next", "standalone", path.basename(appDir), "server.js")
+    );
+  });
+
+  it("still prefers the root server when the build has one", async () => {
+    const appDir = await makeAppDir();
+    await makeValidBuild(appDir);
+    await makeMonorepoBuild(appDir, path.basename(appDir));
+    const target = await validateTarget(appDir);
+    expect(target.standaloneServer).toBe(path.join(appDir, ".next", "standalone", "server.js"));
+  });
+
   it("fails with NO_BUILD when there is no .next directory", async () => {
     const appDir = await makeAppDir();
     await expect(validateTarget(appDir)).rejects.toMatchObject({

--- a/src/target.ts
+++ b/src/target.ts
@@ -25,7 +25,11 @@ export class TargetError extends Error {
 
 export type ValidatedTarget = {
   appDir: string;
-  /** Absolute path to `.next/standalone/server.js`. */
+  /**
+   * Absolute path to the standalone `server.js`. At the root of
+   * `.next/standalone` for a single-package app; under the app's path relative
+   * to the workspace root for a monorepo.
+   */
   standaloneServer: string;
   appPaths: AppPathsManifest;
   pages: PagesManifest;
@@ -69,6 +73,46 @@ async function readManifest<T>(file: string, parse: (raw: unknown) => T): Promis
 }
 
 /**
+ * Where the standalone build actually put `server.js`.
+ *
+ * A single-package app puts it at the root of the standalone tree. A monorepo
+ * does not: Next preserves the app's path relative to the workspace root it
+ * detected, so an app in `client/` ships its server at
+ * `.next/standalone/client/server.js`, with `node_modules` hoisted one level
+ * above it. Looking only at the root of the tree told those users their build
+ * had no standalone output at all, and the only way past the message was to
+ * move the tree by hand — which is what #71 did before it could run.
+ *
+ * That suffix is the app directory's own chain, so the candidates are
+ * enumerable without walking the build: `client`, then `apps/client`, and so
+ * on. A handful of `access` calls, and no guess about which `server.js` in a
+ * tree full of dependencies is the right one.
+ */
+async function findStandaloneServer(
+  appDir: string,
+  standaloneDir: string
+): Promise<string | undefined> {
+  const atRoot = path.join(standaloneDir, "server.js");
+  if (await exists(atRoot)) {
+    return atRoot;
+  }
+  let current = path.resolve(appDir);
+  let suffix = "";
+  for (;;) {
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    suffix = suffix === "" ? path.basename(current) : path.join(path.basename(current), suffix);
+    const candidate = path.join(standaloneDir, suffix, "server.js");
+    if (await exists(candidate)) {
+      return candidate;
+    }
+    current = parent;
+  }
+}
+
+/**
  * Validates that `appDir` contains a production build with
  * `output: "standalone"` and readable route manifests. Fails fast with an
  * actionable message otherwise.
@@ -82,13 +126,13 @@ export async function validateTarget(appDir: string): Promise<ValidatedTarget> {
     );
   }
 
-  const standaloneServer = path.join(nextDir, "standalone", "server.js");
-  if (!(await exists(standaloneServer))) {
+  const standaloneServer = await findStandaloneServer(appDir, path.join(nextDir, "standalone"));
+  if (standaloneServer === undefined) {
     // This is the first wall every new user hits, so the message carries the
     // exact fix — three real apps needed hand-patching before this existed.
     throw new TargetError(
       "NO_STANDALONE",
-      `No ${standaloneServer}.\n` +
+      `No ${path.join(nextDir, "standalone", "server.js")}.\n` +
         `next-leak measures the standalone server bundle. Enable it once in next.config:\n\n` +
         `    const nextConfig = {\n` +
         `      output: "standalone",\n` +


### PR DESCRIPTION
Fixes #71.

## What

- `validateTarget` looks for `server.js` under the app directory's own path inside `.next/standalone`, not only at the root of that tree.
- The launch timeout message is built at the moment of the timeout and carries the stderr the measured process wrote while starting.
- The wait for the control channel and the wait for the app port get one budget each instead of sharing one. Default 60 s, moved with `--ready-timeout <seconds>` (capped at 600).
- README: the monorepo layout, and why flattening it by hand breaks a pnpm build.

## Why

The first bug report from someone who is not me, and it is three failures stacked on each other. The tool only showed the last one.

**The build was fine; the lookup was not.** A workspace build does not put `server.js` at the root of `.next/standalone`. Next keeps the app's path relative to the workspace root it detected, so an app in `client/` ships its server at `.next/standalone/client/server.js` with `node_modules` hoisted above it. `validateTarget` only looked at the root, so a correct standalone build was told to enable standalone output.

Reproduced on Next 16.3.3, pnpm workspace, app in `client/`:

```
client/.next/standalone/node_modules/.pnpm/...
client/.next/standalone/client/server.js
client/.next/standalone/client/.next/required-server-files.json
```

`standalone/server.js` does not exist. The app directory's own path suffix is now tried after the root — `client`, then `apps/client`, and so on — which is a handful of `access` calls and no guessing about which `server.js` in a tree full of dependencies is the right one.

**The workaround that message pushes people to breaks the build.** Flattening `standalone/client/*` up into `standalone/` is what the reporter had to do. On a pnpm workspace the moved server dies almost immediately with `Cannot find module 'next'`: the entries in `standalone/client/node_modules` are relative symlinks (`next -> ../../node_modules/.pnpm/...`), and a level up they point outside the standalone tree. On an npm workspace the same move survives — there is no `standalone/client/node_modules` at all, and `next` resolves to a real directory at the standalone root. Both checked on minimal fixtures; the README says so.

**"timed out waiting for app" was the tool keeping the answer to itself.** The launcher buffers the measured process's stderr and prints it only when the process **exits**. A boot that hangs instead of dying — the state this message exists for — threw the explanation away and left a port number.

The budget was invisible too: 15 s, hard-coded, and shared with the wait for the control channel. That channel answers when the bootstrap is imported, before the app has loaded a module of its own, so time spent there was deducted from the app's.

## Checklist

- [x] Tests cover the new behavior
- [x] `pnpm typecheck && pnpm test` pass locally
- [x] Verdict semantics untouched, or the mutation suite was run

Verified on the same monorepo fixture: `main` answers with the `NO_STANDALONE` message, this branch measures it — `✔ /[locale]/subscription stable (+0.77 MB/1000 req)` — with nothing moved by hand. A new fixture server that writes to stderr and keeps the loop alive without listening makes the launch reject with that text instead of the port. Typecheck clean, 772 tests green.

Reported by @ucarno, whose `run.json` made all three visible.
