### PR TITLE
fix: stop calling a listening app dead, and wait on the measured route (thanks @ucarno)

### DIFF
--- a/src/__fixtures__/accepts-then-drops-server.js
+++ b/src/__fixtures__/accepts-then-drops-server.js
@@ -1,0 +1,13 @@
+// Accepts every connection and then destroys the socket without answering —
+// what a rewrite proxy does when its upstream is gone. The port is open, so
+// "never listened" is the one thing this app is not doing.
+import http from "node:http";
+
+const port = Number(process.env.PORT ?? 3000);
+const hostname = process.env.HOSTNAME ?? "127.0.0.1";
+
+http
+  .createServer((req, res) => {
+    res.socket?.destroy();
+  })
+  .listen(port, hostname);

--- a/src/__fixtures__/hostile-root-server.js
+++ b/src/__fixtures__/hostile-root-server.js
@@ -1,0 +1,21 @@
+// Listens, serves the route a run would measure, and is useless on `/`: the
+// root redirects between locales forever, the way an i18n middleware does when
+// it cannot pick one. A readiness probe that asks for `/` and follows
+// redirects declares this app dead; it is not, and `/en/subscription` proves
+// it on every request.
+import http from "node:http";
+
+const port = Number(process.env.PORT ?? 3000);
+const hostname = process.env.HOSTNAME ?? "127.0.0.1";
+
+http
+  .createServer((req, res) => {
+    if (req.url === "/en/subscription") {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ ok: true }));
+      return;
+    }
+    res.writeHead(307, { location: req.url === "/" ? "/en" : "/" });
+    res.end();
+  })
+  .listen(port, hostname);

--- a/src/launcher-messages.test.ts
+++ b/src/launcher-messages.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { appNeverListened, explainRuntimeFailure, explainStartupFailure } from "./launcher.js";
+import {
+  appNeverListened,
+  explainRuntimeFailure,
+  explainStartupFailure,
+  meansNotListening,
+  probeFailure,
+} from "./launcher.js";
 
 // Pure message functions, split from launcher.test.ts (which boots real
 // processes and is excluded from mutation runs) so mutation can judge the
@@ -91,14 +97,57 @@ describe("appNeverListened", () => {
   it("hands over what the process wrote while starting", () => {
     const message = appNeverListened("127.0.0.1", 44203, 60_000, "Error: DATABASE_URL is not set\n");
     expect(message).toContain("127.0.0.1:44203");
-    expect(message).toContain("never listened within 60s");
+    expect(message).toContain("never accepted a connection within 60s");
     expect(message).toContain("DATABASE_URL is not set");
   });
 
   it("names the budget and the flag that moves it when the process said nothing", () => {
     const message = appNeverListened("127.0.0.1", 44203, 15_000, "   \n");
-    expect(message).toContain("never listened within 15s");
+    expect(message).toContain("never accepted a connection within 15s");
     expect(message).toContain("wrote nothing to stderr");
     expect(message).toContain("--ready-timeout");
+  });
+});
+
+// The probe used to collapse every failure into "not listening yet". Only one
+// of these is that; the rest are answers from a port that was open all along.
+describe("probeFailure", () => {
+  it("digs the code out of the TypeError fetch rejects with", () => {
+    const failed = new TypeError("fetch failed", {
+      cause: Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:44203"), {
+        code: "ECONNREFUSED",
+      }),
+    });
+    expect(probeFailure(failed)).toBe("ECONNREFUSED");
+  });
+
+  it("falls back to the inner message when there is no code", () => {
+    const failed = new TypeError("fetch failed", {
+      cause: new Error("redirect count exceeded"),
+    });
+    expect(probeFailure(failed)).toBe("redirect count exceeded");
+  });
+});
+
+describe("meansNotListening", () => {
+  it("is true only for a refused connection", () => {
+    expect(meansNotListening("ECONNREFUSED")).toBe(true);
+    expect(meansNotListening("EHOSTUNREACH")).toBe(true);
+  });
+
+  it("is false for everything that happens after the handshake", () => {
+    // Measured on Node 24: a socket destroyed mid-request, a reset, and a
+    // redirect loop all reach the probe as failures, and all three prove the
+    // port was open.
+    expect(meansNotListening("UND_ERR_SOCKET")).toBe(false);
+    expect(meansNotListening("ECONNRESET")).toBe(false);
+    expect(meansNotListening("redirect count exceeded")).toBe(false);
+  });
+});
+
+describe("appNeverListened, on a port that really was closed", () => {
+  it("names the refusal it kept seeing", () => {
+    const message = appNeverListened("127.0.0.1", 44203, 60_000, "", "ECONNREFUSED");
+    expect(message).toContain("never accepted a connection (ECONNREFUSED) within 60s");
   });
 });

--- a/src/launcher.test.ts
+++ b/src/launcher.test.ts
@@ -12,6 +12,12 @@ const fakeServer = fileURLToPath(new URL("./__fixtures__/fake-standalone-server.
 const hangingServer = fileURLToPath(
   new URL("./__fixtures__/hangs-without-listening.js", import.meta.url)
 );
+const hostileRootServer = fileURLToPath(
+  new URL("./__fixtures__/hostile-root-server.js", import.meta.url)
+);
+const dropsConnectionsServer = fileURLToPath(
+  new URL("./__fixtures__/accepts-then-drops-server.js", import.meta.url)
+);
 
 async function freePort(): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -36,6 +42,54 @@ afterEach(async () => {
 });
 
 describe("launchInstrumented", () => {
+  // #74: the probe asked for `/` and followed its redirects, so an app whose
+  // root bounces between locales — while the measured route serves fine —
+  // spent the whole budget being called dead.
+  it("waits on the route being measured, not on the root", async () => {
+    const workDir = await mkdtemp(path.join(tmpdir(), "next-leak-ready-path-"));
+    app = await launchInstrumented({
+      serverPath: hostileRootServer,
+      workDir,
+      appPort: await freePort(),
+      bootstrapPath,
+      readyPath: "/en/subscription",
+      readyTimeoutMs: 5000,
+    });
+
+    const response = await fetch(`http://127.0.0.1:${app.appPort}/en/subscription`);
+    expect(((await response.json()) as { ok: boolean }).ok).toBe(true);
+  }, 20_000);
+
+  // The same run, judged the old way: a redirect loop on `/` is not a closed
+  // port, and treating it as one is what withdrew a healthy route.
+  it("does not mistake a failing root for a port nobody opened", async () => {
+    const workDir = await mkdtemp(path.join(tmpdir(), "next-leak-ready-root-"));
+    app = await launchInstrumented({
+      serverPath: hostileRootServer,
+      workDir,
+      appPort: await freePort(),
+      bootstrapPath,
+      readyTimeoutMs: 5000,
+    });
+
+    expect(app.pid).toBeGreaterThan(0);
+  }, 20_000);
+
+  // A proxy whose upstream is down accepts the connection and drops it. The
+  // port is open; whatever happens next is the load phase's to report.
+  it("treats a dropped connection as an app that is up", async () => {
+    const workDir = await mkdtemp(path.join(tmpdir(), "next-leak-ready-drop-"));
+    app = await launchInstrumented({
+      serverPath: dropsConnectionsServer,
+      workDir,
+      appPort: await freePort(),
+      bootstrapPath,
+      readyTimeoutMs: 5000,
+    });
+
+    expect(app.pid).toBeGreaterThan(0);
+  }, 20_000);
+
   // A boot that hangs instead of dying keeps the process alive, so the exit
   // path that prints stderr never runs. The user was left with a port number
   // and no reason (#71); the reason was in the buffer the whole time.

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -39,6 +39,13 @@ export type LaunchOptions = {
   /** Path to the built bootstrap module loaded with `--import`. */
   bootstrapPath: string;
   hostname?: string;
+  /**
+   * Path the readiness probe asks for. Defaults to `/`, but a run should pass
+   * the route it is about to measure: an app can serve that route perfectly
+   * and still fail on `/` — an i18n redirect, an auth wall, a rewrite — and
+   * the wait would then be judging a page nobody asked about (#74).
+   */
+  readyPath?: string;
   maxOldSpaceMb?: number;
   /**
    * Budget for each of the two waits below, not for the pair. Default:
@@ -174,11 +181,16 @@ export function appNeverListened(
   hostname: string,
   port: number,
   budgetMs: number,
-  stderr: string
+  stderr: string,
+  lastFailure: string | undefined = undefined
 ): string {
+  // Naming the refusal is what keeps this message honest: it is the evidence
+  // that nothing was there, rather than an inference from a probe that failed
+  // for reasons of its own.
+  const refused = lastFailure === undefined ? "" : ` (${lastFailure})`;
   const head =
     `app on ${hostname}:${port} — the process started and answered on its control ` +
-    `channel, but never listened within ${Math.round(budgetMs / 1000)}s`;
+    `channel, but never accepted a connection${refused} within ${Math.round(budgetMs / 1000)}s`;
   // The app usually said why, on a stream this process has been buffering all
   // along. It was only ever printed when the child exited, so a boot that hung
   // instead of dying — the exact case this message covers — threw the
@@ -192,6 +204,47 @@ export function appNeverListened(
     `during startup — starting the same server.js by hand, with PORT set, hangs ` +
     `the same way and can be interrupted to see where`
   );
+}
+
+/**
+ * Connection errors that mean nothing accepted the connection. Everything
+ * else — a destroyed socket, a reset, a redirect loop, a proxy whose upstream
+ * is down — happens *after* the TCP handshake, and so is proof the port was
+ * open.
+ *
+ * The distinction is the whole point. The probe used to `catch {}` every
+ * failure into "not listening yet", which is true for exactly one of these
+ * cases and a lie for the rest: #74 was an app serving its measured route
+ * while the tool spent 60 s reporting that it never listened.
+ */
+const NOT_LISTENING_CODES = new Set([
+  "ECONNREFUSED",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ENOTFOUND",
+]);
+
+/**
+ * `fetch` rejects with a bare `TypeError: fetch failed`; what happened is one
+ * level down, and not always as a `code` — a redirect loop arrives as a
+ * message with none.
+ */
+export function probeFailure(cause: unknown): string {
+  const inner = (cause as { cause?: unknown })?.cause;
+  const code = (inner as { code?: unknown })?.code;
+  if (typeof code === "string") {
+    return code;
+  }
+  const message = (inner as { message?: unknown })?.message;
+  if (typeof message === "string" && message !== "") {
+    return message;
+  }
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
+/** Whether a probe failure means the port is not open yet. */
+export function meansNotListening(failure: string): boolean {
+  return NOT_LISTENING_CODES.has(failure);
 }
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
@@ -319,15 +372,28 @@ export async function launchInstrumented(options: LaunchOptions): Promise<Launch
     // bootstrap is imported, which is before the app has loaded a single
     // module of its own — so the time the channel took says nothing about
     // how long the app needs, and must not be deducted from it.
+    // GET, not HEAD, and the route the run is about to measure rather than
+    // `/`: the probe should ask for what the load will ask for. `redirect:
+    // "manual"` because a 307 is already an answer — following it can leave
+    // the wait chasing a locale loop that has nothing to do with readiness.
+    let lastFailure: string | undefined;
     await pollUntil(
       Date.now() + readyTimeoutMs,
-      () => appNeverListened(hostname, options.appPort, readyTimeoutMs, stderrWindow()),
+      () => appNeverListened(hostname, options.appPort, readyTimeoutMs, stderrWindow(), lastFailure),
       async () => {
+        const url = `http://${hostname}:${options.appPort}${options.readyPath ?? "/"}`;
         try {
-          await fetch(`http://${hostname}:${options.appPort}/`, { method: "HEAD" });
+          const response = await fetch(url, { method: "GET", redirect: "manual" });
+          await response.body?.cancel();
           return true;
-        } catch {
-          return undefined;
+        } catch (cause) {
+          const failure = probeFailure(cause);
+          lastFailure = failure;
+          // Only a refused connection means "not up yet". Anything else was
+          // answered by something, so the app is listening — whatever it did
+          // afterwards is the load phase's problem to report, not a reason to
+          // call the route failed before measuring it.
+          return meansNotListening(failure) ? undefined : true;
         }
       },
       failed

--- a/src/ritual.ts
+++ b/src/ritual.ts
@@ -367,6 +367,10 @@ export async function runRitual(
     serverPath: options.serverPath,
     workDir: options.workDir,
     bootstrapPath: options.bootstrapPath,
+    // Wait on the route this ritual is about to measure. `/` is a different
+    // page with different failure modes, and readiness judged on it withdrew
+    // routes that were serving fine (#74).
+    readyPath: options.route,
     ...(options.maxOldSpaceMb !== undefined && { maxOldSpaceMb: options.maxOldSpaceMb }),
     ...(options.readyTimeoutMs !== undefined && { readyTimeoutMs: options.readyTimeoutMs }),
   };


### PR DESCRIPTION
Fixes #74.

## What

- The readiness probe waits on the route the ritual is about to measure, not on `/`.
- It asks with `GET` and `redirect: "manual"`, and cancels the body.
- It reads the failure instead of discarding it: only a refused connection keeps the wait going.
- The timeout message names the refusal it kept seeing.

## Why

0.11.1 reported *"the process started and answered on its control channel, but never listened within 60s"* against an app that was listening, and that was serving the exact route the run was about to measure.

The stderr that message now carries said so, and it read as noise: `MaxListenersExceededWarning`, eleven `close` listeners on a `ServerResponse`, stack through `compression` and `httpxy`'s `handleResponse`. That stack only runs when a request arrives. They were the probe's own requests, being served by the app the tool was calling dead.

**It asked for `/`.** The run measures `/en/subscription`. Different pages, different failure modes — and on an app with i18n the root is where a locale redirect lives. A server that loops `/` → `/en` → `/` while serving the measured route with a 200 is withdrawn: `fetch` rejects with `redirect count exceeded`.

**And it was `catch {}`.** Every failure became "not listening yet". Measured on Node 24, that holds for exactly one of them:

| what happened | `cause.code` | port open? |
|---|---|---|
| nothing accepted the connection | `ECONNREFUSED` | no |
| socket destroyed mid-request | `UND_ERR_SOCKET` | yes |
| connection reset | `ECONNRESET` | yes |
| redirect loop | *(none)* `redirect count exceeded` | yes |

Everything below the first row happens after the TCP handshake. The tool spent 60 s collecting proof that the app was up, and reported that it was down.

## Checklist

- [x] Tests cover the new behavior
- [x] `pnpm typecheck && pnpm test` pass locally
- [x] Verdict semantics untouched, or the mutation suite was run

Verified against the real CLI on a monorepo fixture — Next 16.3.3, a `proxy.js` that loops `/` → `/en` → `/`, `/en/subscription` serving 200 with `x-nextjs-cache: HIT`. On `main` the route is withdrawn after 21 s with the message from the report. On this branch it measures: `✔ stable`, -1.00 MB/1000 req. Typecheck clean, 780 tests green.

Reported by @ucarno, whose stderr was the evidence the tool had asked for.
